### PR TITLE
actions: Build deb package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,9 @@ jobs:
       run: mkdir -p ${{runner.workspace}}/pkg/usr/share/applications/; mv .pkg/psst.desktop $_
     - name: Set permissions
       run: chmod 755 ${{runner.workspace}}/pkg/usr/bin/psst-gui
-    - name: Move control
+    - name: Move license
+      run: mkdir -p ${{runner.workspace}}/pkg/usr/share/doc/psst/; mv .pkg/copyright $_
+    - name: Move package config
       run: mkdir -p ${{runner.workspace}}/pkg/; mv .pkg/DEBIAN $_/
     - name: Set version
       run: "echo Version: $(git rev-list --count HEAD) >> ${{runner.workspace}}/pkg/DEBIAN/control"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,3 +44,31 @@ jobs:
         path: |
           target/release/psst-gui
           target/release/psst-gui.exe
+
+  deb:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: actions/download-artifact@v2
+      with:
+        name: psst-gui-Linux
+        path: ${{runner.workspace}}
+    - name: Move executable
+      run: mkdir -p ${{runner.workspace}}/pkg/usr/bin/; mv ${{runner.workspace}}/psst-gui $_
+    - name: Move desktop
+      run: mkdir -p ${{runner.workspace}}/pkg/usr/share/applications/; mv .pkg/psst.desktop $_
+    - name: Set permissions
+      run: chmod 755 ${{runner.workspace}}/pkg/usr/bin/psst-gui
+    - name: Move control
+      run: mkdir -p ${{runner.workspace}}/pkg/; mv .pkg/DEBIAN $_/
+    - name: Set version
+      run: "echo Version: $(git rev-list --count HEAD) >> ${{runner.workspace}}/pkg/DEBIAN/control"
+    - name: Build package
+      run: cat ${{runner.workspace}}/pkg/DEBIAN/control && dpkg-deb -b ${{runner.workspace}}/pkg/ psst_$(git rev-list --count HEAD)_amd64.deb
+    - uses: actions/upload-artifact@v2
+      with:
+        name: psst-deb
+        path: "*.deb"

--- a/.pkg/DEBIAN/control
+++ b/.pkg/DEBIAN/control
@@ -1,0 +1,8 @@
+Package: psst
+Architecture: amd64
+Section: sound
+Priority: optional
+Homepage: https://github.com/jpochyla/psst
+Package-Type: deb
+Depends: libssl1.1, libgtk-3-0, libcairo2
+Description: Fast and multi-platform Spotify client with native GUI

--- a/.pkg/copyright
+++ b/.pkg/copyright
@@ -1,0 +1,12 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: Psst
+Source: https://github.com/jpochyla/psst
+
+Files: *
+Copyright: (c) 2020 Jan Pochyla
+License: MIT
+
+License: MIT
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/.pkg/psst.desktop
+++ b/.pkg/psst.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Categories=Audio;AudioVideo
+Comment=Fast and multi-platform Spotify client with native GUI
+Exec=psst-gui
+Name=Psst
+Terminal=false
+Type=Application
+Version=1.0


### PR DESCRIPTION
This builds a Debian (.deb) package for easier installation on Debian/Ubuntu based systems, as suggested in #16.
This PR is currently based on PR #27, but I can easily rebase it onto the current master branch if you want.