### PR TITLE
fix looping error

### DIFF
--- a/psst-core/src/audio_player.rs
+++ b/psst-core/src/audio_player.rs
@@ -804,7 +804,7 @@ impl Queue {
                 }
             }
             QueueBehavior::LoopTrack => self.position,
-            QueueBehavior::LoopAll => (self.position + 1) % (self.items.len() - 1),
+            QueueBehavior::LoopAll => (self.position + 1) % self.items.len(),
         }
     }
 
@@ -828,7 +828,7 @@ impl Queue {
                 }
             }
             QueueBehavior::LoopTrack => self.position,
-            QueueBehavior::LoopAll => (self.position + 1) % (self.items.len() - 1),
+            QueueBehavior::LoopAll => (self.position + 1) % self.items.len(),
         };
         self.items.get(position)
     }


### PR DESCRIPTION
The current implementation will not play the last song while looking songs. This should resolve the problem and allow all tracks to play.