### PR TITLE
Add more informative error messages

### DIFF
--- a/psst-core/src/error.rs
+++ b/psst-core/src/error.rs
@@ -33,7 +33,11 @@ impl fmt::Display for Error {
                 15 => write!(f, "Authentication failed: extra verification required"),
                 16 => write!(f, "Authentication failed: invalid app key"),
                 17 => write!(f, "Authentication failed: application banned"),
-                _ => write!(f, "Authentication failed with error code {code}", code = code)
+                _ => write!(
+                    f,
+                    "Authentication failed with error code {code}",
+                    code = code
+                ),
             },
             Self::JsonError(err)
             | Self::AudioFetchingError(err)

--- a/psst-core/src/error.rs
+++ b/psst-core/src/error.rs
@@ -21,7 +21,20 @@ impl fmt::Display for Error {
             Self::SessionDisconnected => write!(f, "Session disconnected"),
             Self::UnexpectedResponse => write!(f, "Unknown server response"),
             Self::AudioFileNotFound => write!(f, "Audio file not found"),
-            Self::AuthFailed { code } => write!(f, "Authentication failed: {code}", code = code),
+            Self::AuthFailed { code } => match code {
+                0 => write!(f, "Authentication failed: protocol error"),
+                2 => write!(f, "Authentication failed: try another AP"),
+                5 => write!(f, "Authentication failed: bad connection id"),
+                9 => write!(f, "Authentication failed: travel restriction"),
+                11 => write!(f, "Authentication failed: premium account required"),
+                12 => write!(f, "Authentication failed: bad credentials"),
+                13 => write!(f, "Authentication failed: could not validate credentials"),
+                14 => write!(f, "Authentication failed: account exists"),
+                15 => write!(f, "Authentication failed: extra verification required"),
+                16 => write!(f, "Authentication failed: invalid app key"),
+                17 => write!(f, "Authentication failed: application banned"),
+                _ => write!(f, "Authentication failed with error code {code}", code = code)
+            },
             Self::JsonError(err)
             | Self::AudioFetchingError(err)
             | Self::AudioDecodingError(err)


### PR DESCRIPTION
Related to #13 

Uses the enum variant names in keyexchange.proto to add more informative "Auth failed" error messages.

Let me know if any changes are wanted