### PR TITLE
Remove modal level

### DIFF
--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -46,8 +46,7 @@ pub fn preferences_window() -> WindowDesc<State> {
         .window_size((theme::grid(50.0), theme::grid(69.0)))
         .resizable(false)
         .show_title(false)
-        .transparent_titlebar(true)
-        .set_level(WindowLevel::Modal);
+        .transparent_titlebar(true);
     if cfg!(target_os = "macos") {
         win.menu(menu::main_menu)
     } else {


### PR DESCRIPTION
This is related to #52. By removing the modal level the window can get the proper focus on linux.

A side effect is also that the window will be shown on the currently focused screen if you have multiple screens connected in linux (tested on arch)