### PR TITLE
Implement initial volume slider

### DIFF
--- a/psst-core/src/audio_output.rs
+++ b/psst-core/src/audio_output.rs
@@ -28,6 +28,10 @@ impl AudioOutputRemote {
         self.send(InternalEvent::Resume);
     }
 
+    pub fn set_volume(&self, volume: f32) {
+        self.send(InternalEvent::SetVolume(volume));
+    }
+
     fn send(&self, event: InternalEvent) {
         self.event_sender.send(event).expect("Audio output died");
     }
@@ -111,6 +115,12 @@ impl AudioOutput {
                         device.stop()?;
                     }
                 }
+                InternalEvent::SetVolume(volume) => {
+                    log::debug!("volume has changed");
+                    if device.is_started() {
+                        device.set_master_volume(volume);
+                    }
+                }
                 InternalEvent::Resume => {
                     log::debug!("resuming audio output");
                     if !device.is_started() {
@@ -128,6 +138,7 @@ enum InternalEvent {
     Close,
     Pause,
     Resume,
+    SetVolume(f32),
 }
 
 impl From<miniaudio::Error> for Error {

--- a/psst-core/src/audio_player.rs
+++ b/psst-core/src/audio_player.rs
@@ -264,6 +264,7 @@ impl Player {
             PlayerCommand::Seek { position } => self.seek(position),
             PlayerCommand::Configure { config } => self.configure(config),
             PlayerCommand::SetQueueBehavior { behavior } => self.queue.set_behaviour(behavior),
+            PlayerCommand::SetVolume { volume } => self.set_volume(volume),
         }
     }
 
@@ -407,6 +408,10 @@ impl Player {
             item,
             loading_handle,
         };
+    }
+
+    fn set_volume(&mut self, volume: f32) {
+        self.audio_output_remote.set_volume(volume);
     }
 
     fn play_loaded(&mut self, loaded_item: LoadedPlaybackItem) {
@@ -560,6 +565,10 @@ pub enum PlayerCommand {
     },
     SetQueueBehavior {
         behavior: QueueBehavior,
+    },
+    /// A change in volume given in 0 -> 1
+    SetVolume {
+        volume: f32
     },
 }
 

--- a/psst-core/src/audio_player.rs
+++ b/psst-core/src/audio_player.rs
@@ -410,7 +410,7 @@ impl Player {
         };
     }
 
-    fn set_volume(&mut self, volume: f32) {
+    fn set_volume(&mut self, volume: f64) {
         self.audio_output_remote.set_volume(volume);
     }
 
@@ -566,9 +566,9 @@ pub enum PlayerCommand {
     SetQueueBehavior {
         behavior: QueueBehavior,
     },
-    /// A change in volume given in 0 -> 1
+    /// Change playback volume to a value in 0.0..=1.0 range.
     SetVolume {
-        volume: f32
+        volume: f64,
     },
 }
 

--- a/psst-gui/src/data/mod.rs
+++ b/psst-gui/src/data/mod.rs
@@ -41,7 +41,6 @@ pub struct State {
     pub session: SessionHandle,
 
     pub route: Nav,
-    pub volume: f64,
     pub history: Vector<Nav>,
     pub config: Config,
     pub preferences: Preferences,
@@ -61,7 +60,6 @@ impl Default for State {
         Self {
             session: SessionHandle::new(),
             route: Nav::Home,
-            volume: 50.0,
             history: Vector::new(),
             config: Config::default(),
             preferences: Preferences {
@@ -78,6 +76,7 @@ impl Default for State {
                 now_playing: None,
                 queue_behavior: QueueBehavior::Sequential,
                 queue: Vector::new(),
+                volume: 1.0, // 100% volume.
             },
             search: Search {
                 input: "".into(),

--- a/psst-gui/src/data/mod.rs
+++ b/psst-gui/src/data/mod.rs
@@ -41,6 +41,7 @@ pub struct State {
     pub session: SessionHandle,
 
     pub route: Nav,
+    pub volume: f64,
     pub history: Vector<Nav>,
     pub config: Config,
     pub preferences: Preferences,
@@ -60,6 +61,7 @@ impl Default for State {
         Self {
             session: SessionHandle::new(),
             route: Nav::Home,
+            volume: 50.0,
             history: Vector::new(),
             config: Config::default(),
             preferences: Preferences {

--- a/psst-gui/src/data/playback.rs
+++ b/psst-gui/src/data/playback.rs
@@ -10,6 +10,7 @@ pub struct Playback {
     pub now_playing: Option<NowPlaying>,
     pub queue_behavior: QueueBehavior,
     pub queue: Vector<QueuedTrack>,
+    pub volume: f64,
 }
 
 #[derive(Clone, Debug, Data, Lens)]

--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -7,7 +7,8 @@ use crate::{
 };
 use druid::{
     lens::Unit,
-    widget::{CrossAxisAlignment, Either, Flex, Label, Scroll, Split, ViewSwitcher},
+    Env,
+    widget::{CrossAxisAlignment, Either, Flex, Label, Scroll, Slider, Split, ViewSwitcher},
     Insets, Menu, MenuItem, MouseButton, Widget, WidgetExt, WindowDesc, WindowLevel,
 };
 use icons::SvgIcon;
@@ -71,6 +72,9 @@ fn root_widget() -> impl Widget<State> {
         .with_child(sidebar_menu_widget())
         .with_default_spacer()
         .with_flex_child(playlists.expand_height(), 1.0)
+        .with_child(
+            volume_slider()
+        )
         .with_child(user::user_widget())
         .padding(if cfg!(target_os = "macos") {
             Insets::new(0.0, 24.0, 0.0, 0.0)
@@ -110,6 +114,22 @@ fn root_widget() -> impl Widget<State> {
     // .debug_invalidation()
     // .debug_widget_id()
     // .debug_paint_layout()
+}
+
+fn volume_slider() -> impl Widget<State> {
+    let slider = Slider::new();
+        let label = Label::new(|d: &State, _: &Env| format!("Volume: {}", d.volume as i32));
+    Flex::column()
+        .cross_axis_alignment(CrossAxisAlignment::Start)
+        .with_child(
+            label
+        )
+        .with_default_spacer()
+        .with_child(
+            slider
+                .with_range(0.0, 100.0)
+                .lens(State::volume)
+        )
 }
 
 fn sidebar_logo_widget() -> impl Widget<State> {

--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -1,15 +1,14 @@
 use crate::{
     cmd,
     controller::{NavController, PlaybackController, SessionController},
-    data::{Nav, State},
+    data::{Nav, Playback, State},
     ui::utils::Border,
     widget::{icons, Empty, LinkExt, ThemeScope, ViewDispatcher},
 };
 use druid::{
     lens::Unit,
-    Env,
     widget::{CrossAxisAlignment, Either, Flex, Label, Scroll, Slider, Split, ViewSwitcher},
-    Insets, Menu, MenuItem, MouseButton, Widget, WidgetExt, WindowDesc, WindowLevel,
+    Insets, LensExt, Menu, MenuItem, MouseButton, Widget, WidgetExt, WindowDesc, WindowLevel,
 };
 use icons::SvgIcon;
 
@@ -72,9 +71,8 @@ fn root_widget() -> impl Widget<State> {
         .with_child(sidebar_menu_widget())
         .with_default_spacer()
         .with_flex_child(playlists.expand_height(), 1.0)
-        .with_child(
-            volume_slider()
-        )
+        .with_child(volume_slider())
+        .with_default_spacer()
         .with_child(user::user_widget())
         .padding(if cfg!(target_os = "macos") {
             Insets::new(0.0, 24.0, 0.0, 0.0)
@@ -117,19 +115,25 @@ fn root_widget() -> impl Widget<State> {
 }
 
 fn volume_slider() -> impl Widget<State> {
-    let slider = Slider::new();
-        let label = Label::new(|d: &State, _: &Env| format!("Volume: {}", d.volume as i32));
     Flex::column()
-        .cross_axis_alignment(CrossAxisAlignment::Start)
         .with_child(
-            label
+            Label::dynamic(|&volume: &f64, _| format!("Volume: {}%", (volume * 100.0).floor()))
+                .with_text_color(theme::PLACEHOLDER_COLOR)
+                .with_text_size(theme::TEXT_SIZE_SMALL),
         )
         .with_default_spacer()
         .with_child(
-            slider
-                .with_range(0.0, 100.0)
-                .lens(State::volume)
+            Slider::new()
+                .with_range(0.0, 1.0)
+                .expand_width()
+                .env_scope(|env, _| {
+                    env.set(theme::BASIC_WIDGET_HEIGHT, theme::grid(1.5));
+                    env.set(theme::FOREGROUND_LIGHT, env.get(theme::GREY_400));
+                    env.set(theme::FOREGROUND_DARK, env.get(theme::GREY_400));
+                }),
         )
+        .padding((theme::grid(1.5), 0.0))
+        .lens(State::playback.then(Playback::volume))
 }
 
 fn sidebar_logo_widget() -> impl Widget<State> {


### PR DESCRIPTION
This pull requests implements a working version of a volume slider. It was one of the pain points when using the application :D. As I was unsure about the location, I just put it somewhere where it could be easily accessed and thus not intrude on the rest of the application.

The slider allows values between 0 - 100 and displays the values as integer in the label (but is chosen as f32).

<details>
<summary>Image of the sidebar</summary>

![screen](https://user-images.githubusercontent.com/35100156/119901182-dc069680-bf45-11eb-9f0b-165bf79c7ce7.png)

</details>

I so far had no issues with it and it seems to perform well.
