### PR TITLE
gui: Add MPRIS support

### DIFF
--- a/psst-gui/src/controller/playback.rs
+++ b/psst-gui/src/controller/playback.rs
@@ -82,7 +82,10 @@ impl PlaybackController {
             }
             _ => unreachable!(),
         };
-        #[cfg(not(target_os = "windows"))]
+        #[cfg(target_os = "linux")]
+        let mut media_controls = MediaControls::new_with_name("psst", "Psst");
+
+        #[cfg(all(not(target_os = "windows"), not(target_os = "linux")))]
         let mut media_controls = MediaControls::new();
 
         media_controls


### PR DESCRIPTION
Just changes a few lines to make it work the media controls work with Linux. I also had to change `cover_url` to `None` in line 186 to make it compile, but its not included in this PR, since that's outside its scope.