### PR TITLE
MediaControls: replace `new_with_name` with `new`

### DIFF
--- a/psst-gui/src/controller/playback.rs
+++ b/psst-gui/src/controller/playback.rs
@@ -83,10 +83,8 @@ impl PlaybackController {
             }
             _ => unreachable!(),
         };
-        #[cfg(target_os = "linux")]
-        let mut media_controls = MediaControls::new_with_name("psst", "Psst");
 
-        #[cfg(all(not(target_os = "windows"), not(target_os = "linux")))]
+        #[cfg(not(target_os = "windows"))]
         let mut media_controls = MediaControls::new();
 
         media_controls


### PR DESCRIPTION
This fixes #64. I didn't find `new_with_name` in the docs for `MediaControls`, so just replaced it with `new`.