### PR TITLE
Hide console window on windows

### DIFF
--- a/psst-gui/src/main.rs
+++ b/psst-gui/src/main.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 #![allow(clippy::new_without_default)]
 
 mod cmd;


### PR DESCRIPTION
This change will prevent the console window from showing when running release builds on windows