### PR TITLE
More visible active track

### DIFF
--- a/psst-gui/src/main.rs
+++ b/psst-gui/src/main.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 #![allow(clippy::new_without_default)]
 
 mod cmd;

--- a/psst-gui/src/ui/theme.rs
+++ b/psst-gui/src/ui/theme.rs
@@ -35,6 +35,7 @@ pub const ICON_SIZE: Size = Size::new(12.0, 12.0);
 pub const ICON_SIZE_LARGE: Size = Size::new(GRID * 2.0, GRID * 2.0);
 
 pub const LINK_HOT_COLOR: Key<Color> = Key::new("app.link-hot-color");
+pub const LINK_ACTIVE_COLOR: Key<Color> = Key::new("app.link-active-color");
 pub const LINK_COLD_COLOR: Key<Color> = Key::new("app.link-cold-color");
 
 pub fn setup(env: &mut Env, state: &AppState) {
@@ -138,6 +139,7 @@ fn setup_light_theme(env: &mut Env) {
     env.set(RED, Color::rgba8(0xEB, 0x57, 0x57, 0xFF));
 
     env.set(LINK_HOT_COLOR, Color::rgba(0.0, 0.0, 0.0, 0.05));
+    env.set(LINK_ACTIVE_COLOR, Color::rgba(0.0, 0.0, 0.0, 0.025));
     env.set(LINK_COLD_COLOR, Color::rgba(0.0, 0.0, 0.0, 0.0));
 }
 
@@ -156,5 +158,6 @@ fn setup_dark_theme(env: &mut Env) {
     env.set(RED, Color::rgba8(0xEB, 0x57, 0x57, 0xFF));
 
     env.set(LINK_HOT_COLOR, Color::rgba(1.0, 1.0, 1.0, 0.05));
+    env.set(LINK_ACTIVE_COLOR, Color::rgba(1.0, 1.0, 1.0, 0.025));
     env.set(LINK_COLD_COLOR, Color::rgba(1.0, 1.0, 1.0, 0.0));
 }

--- a/psst-gui/src/ui/track.rs
+++ b/psst-gui/src/ui/track.rs
@@ -286,6 +286,7 @@ fn track_widget(display: TrackDisplay) -> impl Widget<TrackRow> {
         .with_child(minor)
         .padding(theme::grid(1.0))
         .link()
+        .active_background(|tr: &TrackRow, _env: &Env| tr.ctx.is_track_playing(&tr.track), theme::LINK_ACTIVE_COLOR)
         .rounded(theme::BUTTON_BORDER_RADIUS)
         .on_ex_click(move |ctx, event, tr: &mut TrackRow, _| match event.button {
             MouseButton::Left => {


### PR DESCRIPTION
Addresses https://github.com/jpochyla/psst/issues/76 by adding a new link background state for when the link is active. I added a function to link which takes a predicate and a background color to render when the predicate returns true.

Dark Mode:
![image](https://user-images.githubusercontent.com/3323631/126051602-349b6f52-ba19-412f-9bc0-bf1b68040c1e.png)

Light Mode:
![image](https://user-images.githubusercontent.com/3323631/126051625-4b85773f-0b60-40b8-8379-2a91cc723b29.png)

Note: I noticed that light mode selection theme is a bit too subtle, so I had to boost the alpha for light mode a bit more than I did for dark mode.