### PR TITLE
Enable socks-proxy feature  for ureq

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,6 +2452,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "socks",
  "url",
  "webpki",
  "webpki-roots",

--- a/psst-gui/Cargo.toml
+++ b/psst-gui/Cargo.toml
@@ -26,7 +26,7 @@ raw-window-handle = "0.3"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 souvlaki = "0.4"
-ureq = { version = "2.1", features = ["json"] }
+ureq = { version = "2.1", features = ["json", "socks-proxy"] }
 url = "2.2"
 
 [target.'cfg(windows)'.build-dependencies]


### PR DESCRIPTION
Otherwise one can connect but then UI have error everywhere with something like:

```
ERROR psst_gui::widget::promise] async: WebApiError("https://api.spotify.com/v1/me/playlists?limit=50&offset=0: Connection Failed: Connect error: SOCKS5 feature disabled.")
```