### PR TITLE
readme - wrote that it needs rustc 1.54.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sudo dnf install openssl-devel gtk3-devel cairo-devel
 
 ##### Building
 
-On all platforms, the **latest Rust stable** is neeed.
+On all platforms, the **latest Rust stable** (at least 1.54.0) is neeed.
 
 Development build:
 ```shell


### PR DESCRIPTION
Explicit is better than implicit. Solves #114.