### PR TITLE
Fix wrong expiration time parsing

### DIFF
--- a/psst-core/src/cdn.rs
+++ b/psst-core/src/cdn.rs
@@ -140,13 +140,13 @@ fn parse_total_content_length(response: &ureq::Response) -> u64 {
 }
 
 /// Parses an expiration of an audio file URL.
-/// Expiration is stored at the beginning of the first query parameter, i.e.:
+/// Expiration is stored as `exp` field after `__token__`:
 ///
-/// .../59db919e18d6336461a0c71da051842ceef1b5af?1602319025_wu-SPeHxn...
-///                                              ^========^
+/// .../...a35817ca410?__token__=exp=1629466995~hmac=df348...
+///                                  ^========^
 fn parse_expiration(url: &str) -> Option<Duration> {
-    let first_param = url.split('?').nth(1)?;
-    let expires_millis = first_param.split('_').next()?;
+    let token_exp = url.split("__token__=exp=").nth(1)?;
+    let expires_millis = token_exp.split('~').next()?;
     let expires_millis = expires_millis.parse().ok()?;
     let expires = Duration::from_millis(expires_millis);
     Some(expires)

--- a/psst-core/src/cdn.rs
+++ b/psst-core/src/cdn.rs
@@ -140,13 +140,24 @@ fn parse_total_content_length(response: &ureq::Response) -> u64 {
 }
 
 /// Parses an expiration of an audio file URL.
-/// Expiration is stored as `exp` field after `__token__`:
+/// Expiration is stored either as:
 ///
-/// .../...a35817ca410?__token__=exp=1629466995~hmac=df348...
-///                                  ^========^
+///  1. `exp` field after `__token__`:
+///     .../...a35817ca410?__token__=exp=1629466995~hmac=df348...
+///                                      ^========^
+///  2. or at the beginning of the first query parameter:
+///     .../59db919e18d6336461a0c71da051842ceef1b5af?1602319025_wu-SPeHxn...
+///                                                  ^========^
 fn parse_expiration(url: &str) -> Option<Duration> {
-    let token_exp = url.split("__token__=exp=").nth(1)?;
-    let expires_millis = token_exp.split('~').next()?;
+    let token_exp = url.split("__token__=exp=").nth(1);
+    let expires_millis = if let Some(token_exp) = token_exp {
+        // Parse from the expiration token param.
+        token_exp.split('~').next()?
+    } else {
+        // Parse from the first param.
+        let first_param = url.split('?').nth(1)?;
+        first_param.split('_').next()?
+    };
     let expires_millis = expires_millis.parse().ok()?;
     let expires = Duration::from_millis(expires_millis);
     Some(expires)


### PR DESCRIPTION
The parsing of the expiration time seems to be wrong (probably outdated?), giving me a `failed to parse expiration time from URL ...` warning.

Not sure whether these server responses can differ across operating systems or so. At least building from master on macOS  10.15 I get a response of the form `.../...a35817ca410?__token__=exp=1629466995~hmac=df348...`.

With the changes in this PR, the issue seems fixed – the log says that a new token has been requested because it was outdated.