### PR TITLE
Store shortcuts in config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2003,7 +2003,8 @@ dependencies = [
 [[package]]
 name = "souvlaki"
 version = "0.4.1"
-source = "git+https://github.com/Sinono3/souvlaki#ab184816861bf2d691a1cf30db834cad383f70d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5834fb7421062570b409e49ecebee68d303866c8ba1c3f81138a82e8eba64081"
 dependencies = [
  "block",
  "cocoa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,7 +489,7 @@ checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 [[package]]
 name = "druid"
 version = "0.7.0"
-source = "git+https://github.com/JuliDi/druid?branch=psst#a31679cdc6e0d4bebb96f5c50970ff9afa254851"
+source = "git+https://github.com/jpochyla/druid?branch=psst#30aa0baab6f9801aba16db48793d97a23839856a"
 dependencies = [
  "console_error_panic_hook",
  "druid-derive",
@@ -511,7 +511,7 @@ dependencies = [
 [[package]]
 name = "druid-derive"
 version = "0.4.0"
-source = "git+https://github.com/JuliDi/druid?branch=psst#a31679cdc6e0d4bebb96f5c50970ff9afa254851"
+source = "git+https://github.com/jpochyla/druid?branch=psst#30aa0baab6f9801aba16db48793d97a23839856a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "druid-shell"
 version = "0.7.0"
-source = "git+https://github.com/JuliDi/druid?branch=psst#a31679cdc6e0d4bebb96f5c50970ff9afa254851"
+source = "git+https://github.com/jpochyla/druid?branch=psst#30aa0baab6f9801aba16db48793d97a23839856a"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -542,7 +542,7 @@ dependencies = [
  "image",
  "instant",
  "js-sys",
- "keyboard-types 0.5.0",
+ "keyboard-types",
  "kurbo",
  "lazy_static",
  "objc",
@@ -1148,19 +1148,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a989afac88279b0482f402d234b5fbd405bf1ad051308595b58de4e6de22346b"
 dependencies = [
  "bitflags",
- "serde",
- "unicode-segmentation",
-]
-
-[[package]]
-name = "keyboard-types"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5168b1079eb8dc457c80f263c1f521578e458c1b21ae42328f65117738d31396"
-dependencies = [
- "bitflags",
- "serde",
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -1681,7 +1668,6 @@ dependencies = [
  "env_logger",
  "fs_extra",
  "itertools 0.10.1",
- "keyboard-types 0.6.1",
  "log",
  "lru-cache",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,7 +489,7 @@ checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 [[package]]
 name = "druid"
 version = "0.7.0"
-source = "git+https://github.com/jpochyla/druid?branch=psst#30aa0baab6f9801aba16db48793d97a23839856a"
+source = "git+https://github.com/JuliDi/druid?branch=psst#a31679cdc6e0d4bebb96f5c50970ff9afa254851"
 dependencies = [
  "console_error_panic_hook",
  "druid-derive",
@@ -511,7 +511,7 @@ dependencies = [
 [[package]]
 name = "druid-derive"
 version = "0.4.0"
-source = "git+https://github.com/jpochyla/druid?branch=psst#30aa0baab6f9801aba16db48793d97a23839856a"
+source = "git+https://github.com/JuliDi/druid?branch=psst#a31679cdc6e0d4bebb96f5c50970ff9afa254851"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "druid-shell"
 version = "0.7.0"
-source = "git+https://github.com/jpochyla/druid?branch=psst#30aa0baab6f9801aba16db48793d97a23839856a"
+source = "git+https://github.com/JuliDi/druid?branch=psst#a31679cdc6e0d4bebb96f5c50970ff9afa254851"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -542,7 +542,7 @@ dependencies = [
  "image",
  "instant",
  "js-sys",
- "keyboard-types",
+ "keyboard-types 0.5.0",
  "kurbo",
  "lazy_static",
  "objc",
@@ -1148,6 +1148,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a989afac88279b0482f402d234b5fbd405bf1ad051308595b58de4e6de22346b"
 dependencies = [
  "bitflags",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "keyboard-types"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5168b1079eb8dc457c80f263c1f521578e458c1b21ae42328f65117738d31396"
+dependencies = [
+ "bitflags",
+ "serde",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1221,9 +1234,9 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "miniaudio"
@@ -1668,6 +1681,7 @@ dependencies = [
  "env_logger",
  "fs_extra",
  "itertools 0.10.1",
+ "keyboard-types 0.6.1",
  "log",
  "lru-cache",
  "once_cell",
@@ -2003,8 +2017,7 @@ dependencies = [
 [[package]]
 name = "souvlaki"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5834fb7421062570b409e49ecebee68d303866c8ba1c3f81138a82e8eba64081"
+source = "git+https://github.com/Sinono3/souvlaki#ab184816861bf2d691a1cf30db834cad383f70d6"
 dependencies = [
  "block",
  "cocoa",
@@ -2292,18 +2305,18 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
+checksum = "2ca517f43f0fb96e0c3072ed5c275fe5eece87e8cb52f4a77b69226d3b1c9df8"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab69019741fca4d98be3c62d2b75254528b5432233fd8a4d2739fec20278de48"
+checksum = "b9cbe87a2fa7e35900ce5de20220a582a9483a7063811defce79d7cbd59d4cfe"
 dependencies = [
  "ansi_term",
  "sharded-slab",

--- a/psst-gui/Cargo.toml
+++ b/psst-gui/Cargo.toml
@@ -12,8 +12,9 @@ psst-core = { path = "../psst-core" }
 
 chrono = { version = "0.4", features = ["serde"] }
 crossbeam-channel = "0.5"
-druid-shell = { git = "https://github.com/jpochyla/druid", branch = "psst", features = ["raw-win-handle"] }
-druid = { git = "https://github.com/jpochyla/druid", branch = "psst", features = ["im", "image", "jpeg", "png", "serde"] }
+druid-shell = { git = "https://github.com/JuliDi/druid", branch = "psst", features = ["raw-win-handle"] }
+druid = { git = "https://github.com/JuliDi/druid", branch = "psst", features = ["im", "image", "jpeg", "png", "serde"] }
+keyboard-types = { version = "0.6.1", features = ["serde"] }
 env_logger = "0.8"
 fs_extra = "1.2"
 itertools = "0.10"
@@ -26,7 +27,7 @@ rand = "0.8"
 raw-window-handle = "0.3"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
-souvlaki = "0.4"
+souvlaki = { git = "https://github.com/Sinono3/souvlaki" }
 ureq = { version = "2.1", features = ["json", "socks-proxy"] }
 url = "2.2"
 

--- a/psst-gui/Cargo.toml
+++ b/psst-gui/Cargo.toml
@@ -26,7 +26,7 @@ rand = "0.8"
 raw-window-handle = "0.3"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
-souvlaki = { git = "https://github.com/Sinono3/souvlaki" }
+souvlaki = "0.4"
 ureq = { version = "2.1", features = ["json", "socks-proxy"] }
 url = "2.2"
 

--- a/psst-gui/Cargo.toml
+++ b/psst-gui/Cargo.toml
@@ -12,9 +12,8 @@ psst-core = { path = "../psst-core" }
 
 chrono = { version = "0.4", features = ["serde"] }
 crossbeam-channel = "0.5"
-druid-shell = { git = "https://github.com/JuliDi/druid", branch = "psst", features = ["raw-win-handle"] }
-druid = { git = "https://github.com/JuliDi/druid", branch = "psst", features = ["im", "image", "jpeg", "png", "serde"] }
-keyboard-types = { version = "0.6.1", features = ["serde"] }
+druid-shell = { git = "https://github.com/jpochyla/druid", branch = "psst", features = ["raw-win-handle"] }
+druid = { git = "https://github.com/jpochyla/druid", branch = "psst", features = ["im", "image", "jpeg", "png", "serde"] }
 env_logger = "0.8"
 fs_extra = "1.2"
 itertools = "0.10"

--- a/psst-gui/src/controller/input.rs
+++ b/psst-gui/src/controller/input.rs
@@ -6,7 +6,6 @@ use druid::{
 
 use crate::cmd;
 use druid::widget::ValueTextBox;
-use std::ops::DerefMut;
 
 pub struct InputController {
     on_submit: Option<Box<dyn Fn(&mut EventCtx, &mut String, &Env)>>,

--- a/psst-gui/src/controller/input.rs
+++ b/psst-gui/src/controller/input.rs
@@ -5,6 +5,8 @@ use druid::{
 };
 
 use crate::cmd;
+use druid::widget::ValueTextBox;
+use std::ops::DerefMut;
 
 pub struct InputController {
     on_submit: Option<Box<dyn Fn(&mut EventCtx, &mut String, &Env)>>,
@@ -28,6 +30,32 @@ impl Controller<String, TextBox<String>> for InputController {
     fn event(
         &mut self,
         child: &mut TextBox<String>,
+        ctx: &mut EventCtx,
+        event: &Event,
+        data: &mut String,
+        env: &Env,
+    ) {
+        self.match_event(child, ctx, event, data, env)
+    }
+}
+
+impl Controller<String, ValueTextBox<String>> for InputController {
+    fn event(
+        &mut self,
+        child: &mut ValueTextBox<String>,
+        ctx: &mut EventCtx,
+        event: &Event,
+        data: &mut String,
+        env: &Env,
+    ) {
+        self.match_event(child, ctx, event, data, env)
+    }
+}
+
+impl InputController {
+    fn match_event(
+        &mut self,
+        child: &mut impl Widget<String>,
         ctx: &mut EventCtx,
         event: &Event,
         data: &mut String,

--- a/psst-gui/src/controller/mod.rs
+++ b/psst-gui/src/controller/mod.rs
@@ -6,6 +6,7 @@ mod on_cmd;
 mod on_cmd_async;
 mod playback;
 mod session;
+mod shortcut_formatter;
 
 pub use debounce::Debounce;
 pub use ex_click::ExClick;
@@ -15,3 +16,4 @@ pub use on_cmd::OnCmd;
 pub use on_cmd_async::OnCmdAsync;
 pub use playback::PlaybackController;
 pub use session::SessionController;
+pub use shortcut_formatter::ShortcutFormatter;

--- a/psst-gui/src/controller/playback.rs
+++ b/psst-gui/src/controller/playback.rs
@@ -21,6 +21,7 @@ use souvlaki::{
     MediaControlEvent, MediaControls, MediaMetadata, MediaPlayback, MediaPosition, PlatformConfig,
 };
 
+use crate::data::matches;
 use crate::{
     cmd,
     data::{
@@ -394,23 +395,23 @@ where
                 ctx.set_handled();
             }
             //
-            Event::KeyDown(key) if key.code == Code::Space => {
+            Event::KeyDown(key) if matches(key, &data.config.shortcuts.play_resume) => {
                 self.pause_or_resume();
                 ctx.set_handled();
             }
-            Event::KeyDown(key) if key.code == Code::ArrowRight => {
+            Event::KeyDown(key) if matches(key, &data.config.shortcuts.next_song) => {
                 self.next();
                 ctx.set_handled();
             }
-            Event::KeyDown(key) if key.code == Code::ArrowLeft => {
+            Event::KeyDown(key) if matches(key, &data.config.shortcuts.previous_song) => {
                 self.previous();
                 ctx.set_handled();
             }
-            Event::KeyDown(key) if matches(key, data.shortcuts.volume_increase) => {
+            Event::KeyDown(key) if matches(key, &data.config.shortcuts.volume_increase) => {
                 data.playback.volume = (data.playback.volume + 0.1).min(1.0);
                 ctx.set_handled();
             }
-            Event::KeyDown(key) if data.shortcuts.volume_decrease().matches(key) => {
+            Event::KeyDown(key) if matches(key, &data.config.shortcuts.volume_decrease) => {
                 data.playback.volume = (data.playback.volume - 0.1).max(0.0);
                 ctx.set_handled();
             }

--- a/psst-gui/src/controller/playback.rs
+++ b/psst-gui/src/controller/playback.rs
@@ -24,8 +24,8 @@ use souvlaki::{
 use crate::{
     cmd,
     data::{
-        AppState, Config, Playback, PlaybackOrigin, PlaybackState, QueueBehavior, QueuedTrack,
-        TrackId,
+        AppState, Config, KbShortcut, Playback, PlaybackOrigin, PlaybackState, QueueBehavior,
+        QueuedTrack, TrackId,
     },
 };
 
@@ -406,11 +406,11 @@ where
                 self.previous();
                 ctx.set_handled();
             }
-            Event::KeyDown(key) if key.key == KbKey::Character("+".to_string()) => {
+            Event::KeyDown(key) if data.config.shortcuts.volume_increase.matches(key) => {
                 data.playback.volume = (data.playback.volume + 0.1).min(1.0);
                 ctx.set_handled();
             }
-            Event::KeyDown(key) if key.key == KbKey::Character("-".to_string()) => {
+            Event::KeyDown(key) if data.config.shortcuts.volume_decrease.matches(key) => {
                 data.playback.volume = (data.playback.volume - 0.1).max(0.0);
                 ctx.set_handled();
             }

--- a/psst-gui/src/controller/playback.rs
+++ b/psst-gui/src/controller/playback.rs
@@ -406,11 +406,11 @@ where
                 self.previous();
                 ctx.set_handled();
             }
-            Event::KeyDown(key) if data.config.shortcuts.volume_increase.matches(key) => {
+            Event::KeyDown(key) if matches(key, data.shortcuts.volume_increase) => {
                 data.playback.volume = (data.playback.volume + 0.1).min(1.0);
                 ctx.set_handled();
             }
-            Event::KeyDown(key) if data.config.shortcuts.volume_decrease.matches(key) => {
+            Event::KeyDown(key) if data.shortcuts.volume_decrease().matches(key) => {
                 data.playback.volume = (data.playback.volume - 0.1).max(0.0);
                 ctx.set_handled();
             }

--- a/psst-gui/src/controller/playback.rs
+++ b/psst-gui/src/controller/playback.rs
@@ -7,7 +7,7 @@ use crossbeam_channel::Sender;
 use druid::{
     im::Vector,
     widget::{prelude::*, Controller},
-    Code, ExtEventSink, InternalLifeCycle, KbKey, WindowHandle,
+    ExtEventSink, InternalLifeCycle, WindowHandle,
 };
 use psst_core::{
     audio_normalize::NormalizationLevel,
@@ -25,8 +25,8 @@ use crate::data::matches;
 use crate::{
     cmd,
     data::{
-        AppState, Config, KbShortcut, Playback, PlaybackOrigin, PlaybackState, QueueBehavior,
-        QueuedTrack, TrackId,
+        AppState, Config, Playback, PlaybackOrigin, PlaybackState, QueueBehavior, QueuedTrack,
+        TrackId,
     },
 };
 

--- a/psst-gui/src/controller/shortcut_formatter.rs
+++ b/psst-gui/src/controller/shortcut_formatter.rs
@@ -1,0 +1,32 @@
+use crate::data::KbShortcut;
+use druid::text::{Formatter, Selection, Validation, ValidationError};
+use druid::widget::{TextBoxEvent, ValidationDelegate};
+use druid::EventCtx;
+use std::str::FromStr;
+
+pub struct ShortcutFormatter;
+
+impl Formatter<String> for ShortcutFormatter {
+    fn format(&self, value: &String) -> String {
+        value.to_string()
+    }
+
+    fn validate_partial_input(&self, input: &str, sel: &Selection) -> Validation {
+        match KbShortcut::from_str(input) {
+            Ok(_) => Validation::success(),
+            Err(e) => Validation::failure(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Invalid Shortcut",
+            )),
+        }
+    }
+
+    fn value(&self, input: &str) -> Result<String, ValidationError> {
+        Ok(KbShortcut::from_str(input)
+            .or(Err(ValidationError::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Invalid Shortcut",
+            ))))?
+            .to_string())
+    }
+}

--- a/psst-gui/src/controller/shortcut_formatter.rs
+++ b/psst-gui/src/controller/shortcut_formatter.rs
@@ -1,7 +1,5 @@
 use crate::data::KbShortcut;
 use druid::text::{Formatter, Selection, Validation, ValidationError};
-use druid::widget::{TextBoxEvent, ValidationDelegate};
-use druid::EventCtx;
 use std::str::FromStr;
 
 pub struct ShortcutFormatter;
@@ -11,10 +9,10 @@ impl Formatter<String> for ShortcutFormatter {
         value.to_string()
     }
 
-    fn validate_partial_input(&self, input: &str, sel: &Selection) -> Validation {
+    fn validate_partial_input(&self, input: &str, _: &Selection) -> Validation {
         match KbShortcut::from_str(input) {
             Ok(_) => Validation::success(),
-            Err(e) => Validation::failure(std::io::Error::new(
+            Err(_) => Validation::failure(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
                 "Invalid Shortcut",
             )),

--- a/psst-gui/src/data/config.rs
+++ b/psst-gui/src/data/config.rs
@@ -11,7 +11,8 @@ use psst_core::{
 use serde::{Deserialize, Serialize};
 
 use super::Promise;
-use crate::data::{KbShortcut, ToKbShortcut};
+use crate::data::KbShortcut;
+use std::str::FromStr;
 
 #[derive(Clone, Debug, Data, Lens)]
 pub struct Preferences {
@@ -35,6 +36,7 @@ impl Preferences {
 pub enum PreferencesTab {
     General,
     Cache,
+    Shortcuts,
 }
 
 #[derive(Clone, Debug, Data, Lens)]
@@ -73,7 +75,6 @@ pub struct Config {
     pub audio_quality: AudioQuality,
     pub theme: Theme,
     pub volume: f64,
-    pub shortcuts: KbShortcuts,
 }
 
 impl Default for Config {
@@ -83,7 +84,6 @@ impl Default for Config {
             audio_quality: Default::default(),
             theme: Default::default(),
             volume: 1.0,
-            shortcuts: KbShortcuts::default(),
         }
     }
 }
@@ -197,23 +197,23 @@ impl Default for Theme {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Data, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Data, Lens, Serialize, Deserialize)]
 pub struct KbShortcuts {
-    pub play_resume: KbShortcut,
-    pub volume_increase: KbShortcut,
-    pub volume_decrease: KbShortcut,
-    pub next_song: KbShortcut,
-    pub previous_song: KbShortcut,
+    pub play_resume: String,
+    pub volume_increase: String,
+    pub volume_decrease: String,
+    pub nextsong: String,
+    pub previous_song: String,
 }
 
 impl Default for KbShortcuts {
     fn default() -> Self {
         Self {
-            play_resume: " ".to_string().to_kbshortcut().unwrap(),
-            volume_increase: "+".to_string().to_kbshortcut().unwrap(),
-            volume_decrease: "-".to_string().to_kbshortcut().unwrap(),
-            next_song: "ArrowRight".to_string().to_kbshortcut().unwrap(),
-            previous_song: "ArrowLeft".to_string().to_kbshortcut().unwrap(),
+            play_resume: " ".to_string(),
+            volume_increase: "+".to_string(),
+            volume_decrease: "-".to_string(),
+            nextsong: "ArrowRight".to_string(),
+            previous_song: "ArrowLeft".to_string(),
         }
     }
 }

--- a/psst-gui/src/data/config.rs
+++ b/psst-gui/src/data/config.rs
@@ -11,9 +11,7 @@ use psst_core::{
 use serde::{Deserialize, Serialize};
 
 use super::Promise;
-use crate::data::KbShortcut;
 use druid::lens::Field;
-use std::str::FromStr;
 
 #[derive(Clone, Debug, Data, Lens)]
 pub struct Preferences {
@@ -244,7 +242,7 @@ impl KbShortcuts {
 impl Default for KbShortcuts {
     fn default() -> Self {
         Self {
-            play_resume: " ".to_string(),
+            play_resume: "Space".to_string(),
             volume_increase: "+".to_string(),
             volume_decrease: "-".to_string(),
             next_song: "ArrowRight".to_string(),

--- a/psst-gui/src/data/config.rs
+++ b/psst-gui/src/data/config.rs
@@ -11,6 +11,7 @@ use psst_core::{
 use serde::{Deserialize, Serialize};
 
 use super::Promise;
+use crate::data::{KbShortcut, ToKbShortcut};
 
 #[derive(Clone, Debug, Data, Lens)]
 pub struct Preferences {
@@ -72,6 +73,7 @@ pub struct Config {
     pub audio_quality: AudioQuality,
     pub theme: Theme,
     pub volume: f64,
+    pub shortcuts: KbShortcuts,
 }
 
 impl Default for Config {
@@ -81,6 +83,7 @@ impl Default for Config {
             audio_quality: Default::default(),
             theme: Default::default(),
             volume: 1.0,
+            shortcuts: KbShortcuts::default(),
         }
     }
 }
@@ -191,5 +194,26 @@ pub enum Theme {
 impl Default for Theme {
     fn default() -> Self {
         Self::Light
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Data, Serialize, Deserialize)]
+pub struct KbShortcuts {
+    pub play_resume: KbShortcut,
+    pub volume_increase: KbShortcut,
+    pub volume_decrease: KbShortcut,
+    pub next_song: KbShortcut,
+    pub previous_song: KbShortcut,
+}
+
+impl Default for KbShortcuts {
+    fn default() -> Self {
+        Self {
+            play_resume: " ".to_string().to_kbshortcut().unwrap(),
+            volume_increase: "+".to_string().to_kbshortcut().unwrap(),
+            volume_decrease: "-".to_string().to_kbshortcut().unwrap(),
+            next_song: "ArrowRight".to_string().to_kbshortcut().unwrap(),
+            previous_song: "ArrowLeft".to_string().to_kbshortcut().unwrap(),
+        }
     }
 }

--- a/psst-gui/src/data/config.rs
+++ b/psst-gui/src/data/config.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 
 use super::Promise;
 use crate::data::KbShortcut;
+use druid::lens::Field;
 use std::str::FromStr;
 
 #[derive(Clone, Debug, Data, Lens)]
@@ -75,6 +76,7 @@ pub struct Config {
     pub audio_quality: AudioQuality,
     pub theme: Theme,
     pub volume: f64,
+    pub shortcuts: KbShortcuts,
 }
 
 impl Default for Config {
@@ -84,6 +86,7 @@ impl Default for Config {
             audio_quality: Default::default(),
             theme: Default::default(),
             volume: 1.0,
+            shortcuts: Default::default(),
         }
     }
 }
@@ -202,8 +205,40 @@ pub struct KbShortcuts {
     pub play_resume: String,
     pub volume_increase: String,
     pub volume_decrease: String,
-    pub nextsong: String,
+    pub next_song: String,
     pub previous_song: String,
+}
+
+impl KbShortcuts {
+    pub fn to_desc_with_lens(
+        &self,
+    ) -> Vec<(
+        Field<fn(&KbShortcuts) -> &String, fn(&mut KbShortcuts) -> &mut String>,
+        String,
+    )> {
+        vec![
+            (
+                druid::lens!(KbShortcuts, play_resume),
+                "Play/Resume".to_string(),
+            ),
+            (
+                druid::lens!(KbShortcuts, volume_increase),
+                "Volume Increase".to_string(),
+            ),
+            (
+                druid::lens!(KbShortcuts, volume_decrease),
+                "Volume Decrease".to_string(),
+            ),
+            (
+                druid::lens!(KbShortcuts, next_song),
+                "Next Song".to_string(),
+            ),
+            (
+                druid::lens!(KbShortcuts, previous_song),
+                "Previous Song".to_string(),
+            ),
+        ]
+    }
 }
 
 impl Default for KbShortcuts {
@@ -212,7 +247,7 @@ impl Default for KbShortcuts {
             play_resume: " ".to_string(),
             volume_increase: "+".to_string(),
             volume_decrease: "-".to_string(),
-            nextsong: "ArrowRight".to_string(),
+            next_song: "ArrowRight".to_string(),
             previous_song: "ArrowLeft".to_string(),
         }
     }

--- a/psst-gui/src/data/kbshortcut.rs
+++ b/psst-gui/src/data/kbshortcut.rs
@@ -1,10 +1,10 @@
-use druid::{Data, Lens};
+use druid::Data;
 use druid_shell::{Code, KbKey, KeyEvent};
-use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+/// Keyboard Shortcut comprised of either a [`KbKey`] or a [`Code`]
 pub enum KbShortcut {
     Key(KbKey),
     Code(Code),
@@ -17,6 +17,7 @@ impl Data for KbShortcut {
 }
 
 impl KbShortcut {
+    /// Return whether a given [`KeyEvent`] matches this shortcut
     pub fn matches(&self, event: &KeyEvent) -> bool {
         match self {
             KbShortcut::Key(key) => &event.key == key,
@@ -25,15 +26,21 @@ impl KbShortcut {
     }
 }
 
+/// Given a [`&str`], return the corresponding [`Code`] or an `Err` if there is no corresponding
+/// code.
+/// TODO: Add more String-to-Code mappings
 fn kb_code_from_str(s: &str) -> Result<Code, ()> {
     match s {
         "NumpadAdd" => Ok(Code::NumpadAdd),
         "Minus" => Ok(Code::Minus),
-        " " | "Space" => Ok(Code::Space),
+        "Space" => Ok(Code::Space),
         "ArrowRight" => Ok(Code::ArrowRight),
         "ArrowLeft" => Ok(Code::ArrowLeft),
         "ArrowUp" => Ok(Code::ArrowUp),
         "ArrowDown" => Ok(Code::ArrowDown),
+        "Backspace" => Ok(Code::Backspace),
+        "Enter" => Ok(Code::Enter),
+        "Tab" => Ok(Code::Tab),
         _ => Err(()),
     }
 }
@@ -74,13 +81,10 @@ impl FromStr for KbShortcut {
     }
 }
 
+/// Return whether a given [`KeyEvent`] matches the code or character given in `str`
 pub fn matches(key_event: &KeyEvent, str: &String) -> bool {
     if let Ok(shortcut) = KbShortcut::from_str(&str) {
-        match shortcut {
-            KbShortcut::Key(str_key) => str_key == key_event.key,
-            KbShortcut::Code(str_code) => str_code == key_event.code,
-        }
-    } else {
-        false
+        return shortcut.matches(key_event);
     }
+    false
 }

--- a/psst-gui/src/data/kbshortcut.rs
+++ b/psst-gui/src/data/kbshortcut.rs
@@ -1,6 +1,8 @@
-use druid::Data;
+use druid::{Data, Lens};
 use druid_shell::{Code, KbKey, KeyEvent};
 use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum KbShortcut {
@@ -23,22 +25,6 @@ impl KbShortcut {
     }
 }
 
-pub trait ToKbShortcut {
-    fn to_kbshortcut(&self) -> Result<KbShortcut, ()>;
-}
-
-impl ToKbShortcut for String {
-    fn to_kbshortcut(&self) -> Result<KbShortcut, ()> {
-        if let Ok(code) = kb_code_from_str(&self) {
-            Ok(KbShortcut::Code(code))
-        } else if self.len() == 1 {
-            Ok(KbShortcut::Key(KbKey::Character(self.clone())))
-        } else {
-            Err(())
-        }
-    }
-}
-
 fn kb_code_from_str(s: &str) -> Result<Code, ()> {
     match s {
         "NumpadAdd" => Ok(Code::NumpadAdd),
@@ -50,4 +36,63 @@ fn kb_code_from_str(s: &str) -> Result<Code, ()> {
         "ArrowDown" => Ok(Code::ArrowDown),
         _ => Err(()),
     }
+}
+
+impl fmt::Display for KbShortcut {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            KbShortcut::Key(key) => {
+                write!(f, "{}", key.to_string())
+            }
+            KbShortcut::Code(code) => {
+                write!(f, "{}", code.to_string())
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ParseShortcutError;
+
+// Generation of an error is completely separate from how it is displayed.
+// There's no need to be concerned about cluttering complex logic with the display style.
+//
+// Note that we don't store any extra info about the errors. This means we can't state
+// which string failed to parse without modifying our types to carry that information.
+impl fmt::Display for ParseShortcutError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Error parsing shortcut!")
+    }
+}
+
+impl FromStr for KbShortcut {
+    type Err = ParseShortcutError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(code) = kb_code_from_str(s) {
+            Ok(KbShortcut::Code(code))
+        } else if s.len() == 1 {
+            Ok(KbShortcut::Key(KbKey::Character(s.to_string())))
+        } else {
+            Err(ParseShortcutError)
+        }
+    }
+}
+
+struct ShortcutLens;
+
+impl Lens<KbShortcut, String> for ShortcutLens {
+    fn with<V, F: FnOnce(&String) -> V>(&self, data: &KbShortcut, f: F) -> V {
+        f(&data.to_string())
+    }
+
+    fn with_mut<V, F: FnOnce(&mut String) -> V>(&self, data: &mut KbShortcut, f: F) -> V {
+        let mut shortcut_as_string = &data.to_string();
+        f(&mut shortcut_as_string)
+    }
+}
+
+pub fn matches(key: KeyEvent, str: String) -> bool {
+    // Make KbShortcut from str, match key.code and key.key to the result and return if it matched
+    // on error return false?
 }

--- a/psst-gui/src/data/kbshortcut.rs
+++ b/psst-gui/src/data/kbshortcut.rs
@@ -52,13 +52,8 @@ impl fmt::Display for KbShortcut {
 }
 
 #[derive(Debug, Clone)]
-struct ParseShortcutError;
+pub struct ParseShortcutError;
 
-// Generation of an error is completely separate from how it is displayed.
-// There's no need to be concerned about cluttering complex logic with the display style.
-//
-// Note that we don't store any extra info about the errors. This means we can't state
-// which string failed to parse without modifying our types to carry that information.
 impl fmt::Display for ParseShortcutError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Error parsing shortcut!")
@@ -79,20 +74,13 @@ impl FromStr for KbShortcut {
     }
 }
 
-struct ShortcutLens;
-
-impl Lens<KbShortcut, String> for ShortcutLens {
-    fn with<V, F: FnOnce(&String) -> V>(&self, data: &KbShortcut, f: F) -> V {
-        f(&data.to_string())
+pub fn matches(key_event: &KeyEvent, str: &String) -> bool {
+    if let Ok(shortcut) = KbShortcut::from_str(&str) {
+        match shortcut {
+            KbShortcut::Key(str_key) => str_key == key_event.key,
+            KbShortcut::Code(str_code) => str_code == key_event.code,
+        }
+    } else {
+        false
     }
-
-    fn with_mut<V, F: FnOnce(&mut String) -> V>(&self, data: &mut KbShortcut, f: F) -> V {
-        let mut shortcut_as_string = &data.to_string();
-        f(&mut shortcut_as_string)
-    }
-}
-
-pub fn matches(key: KeyEvent, str: String) -> bool {
-    // Make KbShortcut from str, match key.code and key.key to the result and return if it matched
-    // on error return false?
 }

--- a/psst-gui/src/data/kbshortcut.rs
+++ b/psst-gui/src/data/kbshortcut.rs
@@ -1,0 +1,53 @@
+use druid::Data;
+use druid_shell::{Code, KbKey, KeyEvent};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum KbShortcut {
+    Key(KbKey),
+    Code(Code),
+}
+
+impl Data for KbShortcut {
+    fn same(&self, other: &Self) -> bool {
+        self == other
+    }
+}
+
+impl KbShortcut {
+    pub fn matches(&self, event: &KeyEvent) -> bool {
+        match self {
+            KbShortcut::Key(key) => &event.key == key,
+            KbShortcut::Code(code) => &event.code == code,
+        }
+    }
+}
+
+pub trait ToKbShortcut {
+    fn to_kbshortcut(&self) -> Result<KbShortcut, ()>;
+}
+
+impl ToKbShortcut for String {
+    fn to_kbshortcut(&self) -> Result<KbShortcut, ()> {
+        if let Ok(code) = kb_code_from_str(&self) {
+            Ok(KbShortcut::Code(code))
+        } else if self.len() == 1 {
+            Ok(KbShortcut::Key(KbKey::Character(self.clone())))
+        } else {
+            Err(())
+        }
+    }
+}
+
+fn kb_code_from_str(s: &str) -> Result<Code, ()> {
+    match s {
+        "NumpadAdd" => Ok(Code::NumpadAdd),
+        "Minus" => Ok(Code::Minus),
+        " " | "Space" => Ok(Code::Space),
+        "ArrowRight" => Ok(Code::ArrowRight),
+        "ArrowLeft" => Ok(Code::ArrowLeft),
+        "ArrowUp" => Ok(Code::ArrowUp),
+        "ArrowDown" => Ok(Code::ArrowDown),
+        _ => Err(()),
+    }
+}

--- a/psst-gui/src/data/mod.rs
+++ b/psst-gui/src/data/mod.rs
@@ -25,9 +25,11 @@ use psst_core::session::SessionService;
 pub use crate::data::{
     album::{Album, AlbumDetail, AlbumLink, AlbumType, Copyright, CopyrightType},
     artist::{Artist, ArtistAlbums, ArtistDetail, ArtistLink, ArtistTracks},
-    config::{AudioQuality, Authentication, Config, Preferences, PreferencesTab, Theme},
+    config::{
+        AudioQuality, Authentication, Config, KbShortcuts, Preferences, PreferencesTab, Theme,
+    },
     ctx::Ctx,
-    kbshortcut::{KbShortcut, ToKbShortcut},
+    kbshortcut::KbShortcut,
     nav::{Nav, SpotifyUrl},
     playback::{
         NowPlaying, Playback, PlaybackOrigin, PlaybackPayload, PlaybackState, QueueBehavior,
@@ -53,6 +55,7 @@ pub struct AppState {
     pub route: Nav,
     pub history: Vector<Nav>,
     pub config: Config,
+    pub shortcuts: KbShortcuts,
     pub preferences: Preferences,
     pub playback: Playback,
     pub search: Search,
@@ -98,6 +101,7 @@ impl AppState {
                 },
                 cache_size: Promise::Empty,
             },
+            shortcuts: KbShortcuts::default(),
             playback,
             search: Search {
                 input: "".into(),

--- a/psst-gui/src/data/mod.rs
+++ b/psst-gui/src/data/mod.rs
@@ -29,7 +29,7 @@ pub use crate::data::{
         AudioQuality, Authentication, Config, KbShortcuts, Preferences, PreferencesTab, Theme,
     },
     ctx::Ctx,
-    kbshortcut::KbShortcut,
+    kbshortcut::{matches, KbShortcut},
     nav::{Nav, SpotifyUrl},
     playback::{
         NowPlaying, Playback, PlaybackOrigin, PlaybackPayload, PlaybackState, QueueBehavior,
@@ -55,7 +55,6 @@ pub struct AppState {
     pub route: Nav,
     pub history: Vector<Nav>,
     pub config: Config,
-    pub shortcuts: KbShortcuts,
     pub preferences: Preferences,
     pub playback: Playback,
     pub search: Search,
@@ -101,7 +100,6 @@ impl AppState {
                 },
                 cache_size: Promise::Empty,
             },
-            shortcuts: KbShortcuts::default(),
             playback,
             search: Search {
                 input: "".into(),

--- a/psst-gui/src/data/mod.rs
+++ b/psst-gui/src/data/mod.rs
@@ -3,6 +3,7 @@ mod artist;
 mod config;
 mod ctx;
 mod id;
+mod kbshortcut;
 mod nav;
 mod playback;
 mod playlist;
@@ -26,6 +27,7 @@ pub use crate::data::{
     artist::{Artist, ArtistAlbums, ArtistDetail, ArtistLink, ArtistTracks},
     config::{AudioQuality, Authentication, Config, Preferences, PreferencesTab, Theme},
     ctx::Ctx,
+    kbshortcut::{KbShortcut, ToKbShortcut},
     nav::{Nav, SpotifyUrl},
     playback::{
         NowPlaying, Playback, PlaybackOrigin, PlaybackPayload, PlaybackState, QueueBehavior,

--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -80,6 +80,7 @@ fn root_widget() -> impl Widget<AppState> {
         .with_child(sidebar_menu_widget())
         .with_default_spacer()
         .with_flex_child(playlists, 1.0)
+        .with_default_spacer()
         .with_child(volume_slider())
         .with_default_spacer()
         .with_child(user::user_widget())

--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -52,7 +52,7 @@ pub fn preferences_window() -> WindowDesc<AppState> {
     let win = WindowDesc::new(preferences_widget())
         .title("Preferences")
         .window_size(win_size)
-        .resizable(false)
+        .resizable(true)
         .show_title(false)
         .transparent_titlebar(true);
     if cfg!(target_os = "macos") {


### PR DESCRIPTION
This is a first attempt at storing keyboard shortcuts in the config, following up on  #111.
Ideally, if you open the preferences now, there is a "shortcuts" tab with some default settings. For now, either a single character (like "+" or "-" for the volume controls) or a `Code` as defined by https://docs.rs/keyboard-types/0.6.1/keyboard_types/enum.Code.html can be entered.

At the moment, the entries are only parsed and validated – I couldn't manage to get proper feedback (like an error message or so) back to the UI when the entered shortcut could not be parsed.

It doesn't seem very straightforward to implement those keyboard shortcuts and recording them by the user would be even better (and is on my todo list). Also, there are probably a lot of corner-cases that might be or become problematic. 

So feedback on this is highly appreciated.