### PR TITLE
Save/restore queue behavior

### DIFF
--- a/psst-gui/src/controller/playback.rs
+++ b/psst-gui/src/controller/playback.rs
@@ -380,7 +380,7 @@ where
             }
             Event::Command(cmd) if cmd.is(cmd::PLAY_QUEUE_BEHAVIOR) => {
                 let behavior = cmd.get_unchecked(cmd::PLAY_QUEUE_BEHAVIOR);
-                data.playback.queue_behavior = behavior.to_owned();
+                data.set_queue_behavior(behavior.to_owned());
                 self.set_queue_behavior(behavior.to_owned());
                 ctx.set_handled();
             }

--- a/psst-gui/src/data/config.rs
+++ b/psst-gui/src/data/config.rs
@@ -10,7 +10,7 @@ use psst_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use super::{Nav, Promise};
+use super::{Nav, Promise, QueueBehavior};
 
 #[derive(Clone, Debug, Data, Lens)]
 pub struct Preferences {
@@ -74,6 +74,7 @@ pub struct Config {
     pub theme: Theme,
     pub volume: f64,
     pub last_route: Option<Nav>,
+    pub queue_behavior: QueueBehavior,
 }
 
 impl Default for Config {
@@ -84,6 +85,7 @@ impl Default for Config {
             theme: Default::default(),
             volume: 1.0,
             last_route: Default::default(),
+            queue_behavior: Default::default(),
         }
     }
 }

--- a/psst-gui/src/data/mod.rs
+++ b/psst-gui/src/data/mod.rs
@@ -78,7 +78,7 @@ impl AppState {
         let playback = Playback {
             state: PlaybackState::Stopped,
             now_playing: None,
-            queue_behavior: QueueBehavior::Sequential,
+            queue_behavior: config.queue_behavior,
             queue: Vector::new(),
             volume: config.volume,
         };
@@ -200,6 +200,12 @@ impl AppState {
         self.playback.state = PlaybackState::Stopped;
         self.playback.now_playing.take();
         self.common_ctx_mut().playback_item.take();
+    }
+
+    pub fn set_queue_behavior(&mut self, queue_behavior: QueueBehavior) {
+        self.playback.queue_behavior = queue_behavior;
+        self.config.queue_behavior = queue_behavior;
+        self.config.save();
     }
 }
 

--- a/psst-gui/src/data/playback.rs
+++ b/psst-gui/src/data/playback.rs
@@ -5,6 +5,7 @@ use druid::{im::Vector, Data, Lens};
 use crate::data::{
     AlbumLink, ArtistLink, AudioAnalysis, Nav, PlaylistLink, Promise, Track, TrackId,
 };
+use serde::{Deserialize, Serialize};
 
 use super::RecommendationsRequest;
 
@@ -23,12 +24,18 @@ pub struct QueuedTrack {
     pub origin: PlaybackOrigin,
 }
 
-#[derive(Copy, Clone, Debug, Data, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Data, Eq, PartialEq, Serialize, Deserialize)]
 pub enum QueueBehavior {
     Sequential,
     Random,
     LoopTrack,
     LoopAll,
+}
+
+impl Default for QueueBehavior {
+    fn default() -> Self {
+        QueueBehavior::Sequential
+    }
 }
 
 #[derive(Copy, Clone, Debug, Data, Eq, PartialEq)]


### PR DESCRIPTION
This PR...

- adds queue behavior to the configuration
- updates and saves the configuration on queue behavior changes
- and restores the queue behavior state on startup

Currently it handles all queue behaviors, but it might make sense to only restore sequential/random (which is my use case), since loop track and loop all are more used on a once-off basis?
