### PR TITLE
gui: Display album art in playback bar

### DIFF
--- a/psst-gui/src/data/playback.rs
+++ b/psst-gui/src/data/playback.rs
@@ -49,11 +49,16 @@ pub struct NowPlaying {
 
 impl NowPlaying {
     pub fn cover_image_url(&self, width: f64, height: f64) -> Option<&str> {
-        self.item
-            .album
-            .as_ref()
+        self.item_album()
             .and_then(|album| album.image(width, height))
             .map(|image| image.url.as_ref())
+    }
+
+    pub fn item_album(&self) -> Option<&AlbumLink> {
+        self.item.album.as_ref().or_else(|| match &self.origin {
+            PlaybackOrigin::Album(album) => Some(album),
+            _ => None,
+        })
     }
 }
 

--- a/psst-gui/src/ui/playback.rs
+++ b/psst-gui/src/ui/playback.rs
@@ -36,17 +36,6 @@ pub fn panel_widget() -> impl Widget<AppState> {
         .controller(PlaybackController::new())
 }
 
-pub fn cover_widget(size: f64) -> impl Widget<NowPlaying> {
-    RemoteImage::new(
-        utils::placeholder_widget(),
-        move |np: &NowPlaying, _| match &np.item.album {
-            Some(album) => album.image(size, size).map(|image| image.url.clone()),
-            None => None,
-        },
-    )
-    .fix_size(size, size)
-}
-
 fn playback_item_widget() -> impl Widget<NowPlaying> {
     let cover_art = cover_widget(theme::grid(10.0));
 
@@ -94,6 +83,13 @@ fn playback_item_widget() -> impl Widget<NowPlaying> {
         .on_click(|ctx, now_playing, _| {
             ctx.submit_command(cmd::NAVIGATE.with(now_playing.origin.to_nav()));
         })
+}
+
+pub fn cover_widget(size: f64) -> impl Widget<NowPlaying> {
+    RemoteImage::new(utils::placeholder_widget(), move |np: &NowPlaying, _| {
+        np.cover_image_url(size, size).map(|url| url.into())
+    })
+    .fix_size(size, size)
 }
 
 fn playback_origin_icon(origin: &PlaybackOrigin) -> &'static SvgIcon {

--- a/psst-gui/src/ui/playback.rs
+++ b/psst-gui/src/ui/playback.rs
@@ -69,7 +69,7 @@ fn playback_item_widget() -> impl Widget<NowPlaying> {
 
     Flex::row()
         .with_child(Flex::column().with_child(cover_art))
-        .with_child(
+        .with_flex_child(
             Flex::column()
                 .cross_axis_alignment(CrossAxisAlignment::Start)
                 .with_child(track_name)
@@ -78,6 +78,7 @@ fn playback_item_widget() -> impl Widget<NowPlaying> {
                 .with_spacer(2.0)
                 .with_child(track_origin)
                 .padding(theme::grid(2.0)),
+            1.0,
         )
         .link()
         .on_click(|ctx, now_playing, _| {


### PR DESCRIPTION
Hey, I'm Matt! This app is great. I want to learn more about how it all fits together. I saw [this comment](https://github.com/jpochyla/psst/issues/113#issuecomment-901996044) from @pythonhacker and figured I'd take a stab at it.

My changes here are fairly basic. I saw `cover_widget` functions defined in files like `ui/artist.rs` and followed suit. I thought filling the available space would look nice and somewhat similar to the _Albums_ tab, but an alternative design would be with rounded corners and margins around the image similar to the _Home_ tab. Let me know if you'd like me to change this!

The current code works in most situations. I can play from a playlist:

<img width="950" alt="Screen Shot 2021-09-13 at 9 10 54 PM" src="https://user-images.githubusercontent.com/820696/133178516-150ff465-94ea-4908-937b-e44aceffe0d7.png">

From my saved tracks:

<img width="946" alt="Screen Shot 2021-09-13 at 9 11 01 PM" src="https://user-images.githubusercontent.com/820696/133178519-af49bcc5-f8c7-4c44-8c9c-7d856c557115.png">

From a Daily Mix:

<img width="946" alt="Screen Shot 2021-09-13 at 9 11 14 PM" src="https://user-images.githubusercontent.com/820696/133178520-4965653a-0818-429f-85b6-24a02e7bcfd2.png">

But when I play from an album view, no album art is displayed:

<img width="939" alt="Screen Shot 2021-09-13 at 9 11 38 PM" src="https://user-images.githubusercontent.com/820696/133178522-88990aed-8716-4521-adeb-96d08b5507f7.png">

Thanks for taking a look!