### PR TITLE
Playlist Manipulation: Adding tracks to playlists

### DIFF
--- a/psst-core/src/item_id.rs
+++ b/psst-core/src/item_id.rs
@@ -1,4 +1,5 @@
 use std::{convert::TryInto, fmt, ops::Deref};
+use crate::error::Error;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ItemIdType {
@@ -54,6 +55,15 @@ impl ItemId {
             Self::from_base62(gid, ItemIdType::Track)
         } else {
             Self::from_base62(gid, ItemIdType::Unknown)
+        }
+    }
+    // Converts an id to an uri as described in: https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids
+    pub fn to_uri(&self) -> Option<String>{
+        let b64 = self.to_base62();
+        return match self.id_type{
+            ItemIdType::Track => Some(format!("spotify:track:{}", b64)),
+            ItemIdType::Podcast => Some(format!("spotify:podcast:{}", b64)),
+            ItemIdType::Unknown => None
         }
     }
 

--- a/psst-gui/src/data/mod.rs
+++ b/psst-gui/src/data/mod.rs
@@ -271,6 +271,13 @@ impl Library {
         }
     }
 
+    pub fn get_owned_playlists(&self, user_id: Arc<str>) -> Vec<&Playlist>{
+        if let Some(saved) = self.playlists.resolved() {
+            saved.iter().filter(|playlist| playlist.owner.id == user_id).collect()
+        } else {
+            Vec::new()
+        }
+    }
     pub fn contains_album(&self, album: &Album) -> bool {
         if let Some(saved) = self.saved_albums.resolved() {
             saved.set.contains(&album.id)

--- a/psst-gui/src/data/mod.rs
+++ b/psst-gui/src/data/mod.rs
@@ -31,7 +31,7 @@ pub use crate::data::{
         NowPlaying, Playback, PlaybackOrigin, PlaybackPayload, PlaybackState, QueueBehavior,
         QueuedTrack,
     },
-    playlist::{Playlist, PlaylistDetail, PlaylistLink, PlaylistTracks},
+    playlist::{Playlist, PlaylistDetail, PlaylistLink, PlaylistTracks, PlaylistTrackModification},
     promise::{Promise, PromiseState},
     recommend::{
         Range, Recommend, Recommendations, RecommendationsKnobs, RecommendationsParams,
@@ -276,6 +276,15 @@ impl Library {
             saved.set.contains(&album.id)
         } else {
             false
+        }
+    }
+    pub fn increment_playlist_track_count(&mut self, playlist_link: PlaylistLink){
+        if let Some(saved) = self.playlists.resolved_mut() {
+            for i in 0..saved.len(){
+                if saved[i].id == playlist_link.id{
+                    saved[i].track_count += 1
+                }
+            }
         }
     }
 }

--- a/psst-gui/src/data/playlist.rs
+++ b/psst-gui/src/data/playlist.rs
@@ -20,6 +20,7 @@ pub struct Playlist {
     #[serde(rename = "tracks")]
     #[serde(deserialize_with = "deserialize_track_count")]
     pub track_count: usize,
+    pub owner: PublicUser
 }
 
 impl Playlist {

--- a/psst-gui/src/data/playlist.rs
+++ b/psst-gui/src/data/playlist.rs
@@ -3,12 +3,19 @@ use std::sync::Arc;
 use druid::{im::Vector, Data, Lens};
 use serde::{Deserialize, Deserializer, Serialize};
 
-use crate::data::{Image, Promise, Track};
+use crate::data::{Image, Promise, Track, TrackId};
+use crate::data::user::PublicUser;
 
 #[derive(Clone, Debug, Data, Lens)]
 pub struct PlaylistDetail {
     pub playlist: Promise<Playlist, PlaylistLink>,
     pub tracks: Promise<PlaylistTracks, PlaylistLink>,
+}
+
+#[derive(Clone, Debug, Data, Lens, Deserialize)]
+pub struct PlaylistTrackModification {
+    pub playlist_link: PlaylistLink,
+    pub track_id: TrackId,
 }
 
 #[derive(Clone, Debug, Data, Lens, Deserialize)]

--- a/psst-gui/src/data/user.rs
+++ b/psst-gui/src/data/user.rs
@@ -7,4 +7,12 @@ use serde::Deserialize;
 pub struct UserProfile {
     pub display_name: Arc<str>,
     pub email: Arc<str>,
+    pub id: Arc<str>
+}
+
+
+#[derive(Clone, Data, Lens, Deserialize, Debug)]
+pub struct PublicUser {
+    pub display_name: Arc<str>,
+    pub id: Arc<str>
 }

--- a/psst-gui/src/webapi/client.rs
+++ b/psst-gui/src/webapi/client.rs
@@ -74,6 +74,9 @@ impl WebApi {
     fn put(&self, path: impl Display) -> Result<Request, Error> {
         self.request("PUT", path)
     }
+    fn post(&self, path: impl Display) -> Result<Request, Error> {
+        self.request("POST", path)
+    }
 
     fn delete(&self, path: impl Display) -> Result<Request, Error> {
         self.request("DELETE", path)

--- a/psst-gui/src/webapi/client.rs
+++ b/psst-gui/src/webapi/client.rs
@@ -415,6 +415,14 @@ impl WebApi {
             })
             .collect())
     }
+
+    // https://developer.spotify.com/documentation/web-api/reference/#endpoint-add-tracks-to-playlist
+    pub fn add_track_to_playlist(&self, playlist_id: &str, track_uri: &str) -> Result<(), Error>{
+        let request = self.post(format!("v1/playlists/{}/tracks", playlist_id))?
+            .query("uris", track_uri);
+        let result = self.send_empty_json(request)?;
+        Ok(result)
+    }
 }
 
 /// Search endpoints.


### PR DESCRIPTION
As described in the commits, this PR is not quite ready to merge with the main project. 

I believe the following problems should be discussed:
Commit 4294be7:
- The current command executor for adding a track to a playlist is in the playlists `list_widget` function. This might not be the optimal position.
- If the request failed, the user should be notified. I believe this could be done with an alert box, but I did not currently find a way to implement this.

Commit 8efb405:
- The UI should be able to have access to the current user's ID without an API call.

Commit a43611e uses `Vec`s instead of the more commonly used `Vector`. 

edit: I was unaware of the draft feature github has but I believe this works just as well.