### PR TITLE
Replace `chrono` with the `time` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,20 +204,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "serde",
- "time 0.1.43",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "chunked_transfer"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1590,7 +1576,6 @@ dependencies = [
 name = "psst-gui"
 version = "0.1.0"
 dependencies = [
- "chrono",
  "crossbeam-channel",
  "druid",
  "druid-shell",
@@ -1608,6 +1593,7 @@ dependencies = [
  "serde",
  "serde_json",
  "souvlaki",
+ "time 0.3.4",
  "ureq",
  "url",
  "winres",
@@ -2155,16 +2141,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "time"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
@@ -2173,9 +2149,20 @@ dependencies = [
  "libc",
  "standback",
  "stdweb",
- "time-macros",
+ "time-macros 0.1.1",
  "version_check",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "time"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99beeb0daeac2bd1e86ac2c21caddecb244b39a093594da1a661ec2060c7aedd"
+dependencies = [
+ "itoa",
+ "libc",
+ "time-macros 0.2.3",
 ]
 
 [[package]]
@@ -2187,6 +2174,12 @@ dependencies = [
  "proc-macro-hack",
  "time-macros-impl",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
 
 [[package]]
 name = "time-macros-impl"

--- a/psst-gui/Cargo.toml
+++ b/psst-gui/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/jpochyla/psst"
 [dependencies]
 psst-core = { path = "../psst-core" }
 
-chrono = { version = "0.4", features = ["serde"] }
 crossbeam-channel = "0.5"
 druid-shell = { git = "https://github.com/jpochyla/druid", branch = "psst", features = ["raw-win-handle"] }
 druid = { git = "https://github.com/jpochyla/druid", branch = "psst", features = ["im", "image", "jpeg", "png", "serde"] }
@@ -27,6 +26,7 @@ raw-window-handle = "0.3"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 souvlaki = "0.4"
+time = { version = "0.3", features = ["macros", "formatting"] }
 ureq = { version = "2.1", features = ["json", "socks-proxy"] }
 url = "2.2"
 

--- a/psst-gui/src/data/utils.rs
+++ b/psst-gui/src/data/utils.rs
@@ -1,18 +1,19 @@
 use std::{
+    convert::TryFrom,
     fmt, hash,
     sync::Arc,
     time::{Duration, SystemTime},
 };
 
-use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
 use druid::{im::Vector, Data, Lens};
 use serde::{Deserialize, Deserializer, Serialize};
+use time::{Date, Month, OffsetDateTime};
 
 #[derive(Clone, Data, Lens)]
 pub struct Cached<T: Data> {
     pub data: T,
     #[data(ignore)]
-    pub cached_at: Option<NaiveDateTime>,
+    pub cached_at: Option<SystemTime>,
 }
 
 impl<T: Data> Cached<T> {
@@ -24,10 +25,9 @@ impl<T: Data> Cached<T> {
     }
 
     pub fn cached(data: T, at: SystemTime) -> Self {
-        let datetime: DateTime<Utc> = at.into();
         Self {
             data,
-            cached_at: Some(datetime.naive_utc()),
+            cached_at: Some(at),
         }
     }
 
@@ -133,25 +133,27 @@ where
     Ok(duration)
 }
 
-pub fn deserialize_date<'de, D>(deserializer: D) -> Result<NaiveDate, D::Error>
+pub fn deserialize_date<'de, D>(deserializer: D) -> Result<Date, D::Error>
 where
     D: Deserializer<'de>,
 {
     let date = String::deserialize(deserializer)?;
     let mut parts = date.splitn(3, '-');
     let year = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
-    let month = parts.next().and_then(|p| p.parse().ok()).unwrap_or(1);
+    let month: u8 = parts.next().and_then(|p| p.parse().ok()).unwrap_or(1);
+    let month = Month::try_from(month).unwrap_or(Month::January);
     let day = parts.next().and_then(|p| p.parse().ok()).unwrap_or(1);
-    NaiveDate::from_ymd_opt(year, month, day)
-        .ok_or_else(|| serde::de::Error::custom("Invalid date"))
+
+    Date::from_calendar_date(year, month, day)
+        .map_err(|_err| serde::de::Error::custom("Invalid date"))
 }
 
-pub fn deserialize_date_option<'de, D>(deserializer: D) -> Result<Option<NaiveDate>, D::Error>
+pub fn deserialize_date_option<'de, D>(deserializer: D) -> Result<Option<Date>, D::Error>
 where
     D: Deserializer<'de>,
 {
     #[derive(Deserialize)]
-    struct Wrapper(#[serde(deserialize_with = "deserialize_date")] NaiveDate);
+    struct Wrapper(#[serde(deserialize_with = "deserialize_date")] Date);
 
     Ok(Option::deserialize(deserializer)?.map(|Wrapper(val)| val))
 }

--- a/psst-gui/src/ui/search.rs
+++ b/psst-gui/src/ui/search.rs
@@ -30,7 +30,7 @@ pub fn input_widget() -> impl Widget<AppState> {
         .with_placeholder("Search")
         .controller(InputController::new().on_submit(|ctx, query, _| {
             if query.trim().is_empty() {
-                return
+                return;
             }
             ctx.submit_command(cmd::NAVIGATE.with(Nav::SearchResults(query.clone().into())));
         }))


### PR DESCRIPTION
Replaces the `chrono` crate with `time` 0.3

Depends on  #207