### PR TITLE
gui: Avoid search action if query is empty

### DIFF
--- a/psst-gui/src/ui/search.rs
+++ b/psst-gui/src/ui/search.rs
@@ -29,6 +29,9 @@ pub fn input_widget() -> impl Widget<AppState> {
     TextBox::new()
         .with_placeholder("Search")
         .controller(InputController::new().on_submit(|ctx, query, _| {
+            if query.trim().is_empty() {
+                return
+            }
             ctx.submit_command(cmd::NAVIGATE.with(Nav::SearchResults(query.clone().into())));
         }))
         .with_id(cmd::WIDGET_SEARCH_INPUT)


### PR DESCRIPTION
This avoid to show api error from spotify.

Signed-off-by: Federico Guerinoni <guerinoni.federico@gmail.com>
Co-authored-by: Paolo Barbolini <paolo@paolo565.org>
