### PR TITLE
document dependency on libasound2-dev, fixes #220

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Our user-interface library, Druid, has two possible backends to choose from on L
 Debian/Ubuntu:
 
 ```shell
-sudo apt-get install libssl-dev libgtk-3-dev libcairo2-dev
+sudo apt-get install libssl-dev libgtk-3-dev libcairo2-dev libasound2-dev
 ```
 
 RHEL/Fedora:


### PR DESCRIPTION
Building on fresh Ubuntu fails without this dependency. Might as well document it along with the others in README.