### PR TITLE
Add track cover art in playlist and search results

### DIFF
--- a/psst-gui/src/data/config.rs
+++ b/psst-gui/src/data/config.rs
@@ -75,6 +75,7 @@ pub struct Config {
     pub volume: f64,
     pub last_route: Option<Nav>,
     pub queue_behavior: QueueBehavior,
+    pub show_track_cover: bool,
 }
 
 impl Default for Config {
@@ -86,6 +87,7 @@ impl Default for Config {
             volume: 1.0,
             last_route: Default::default(),
             queue_behavior: Default::default(),
+            show_track_cover: Default::default(),
         }
     }
 }

--- a/psst-gui/src/data/mod.rs
+++ b/psst-gui/src/data/mod.rs
@@ -85,6 +85,7 @@ impl AppState {
         let common_ctx = Arc::new(CommonCtx {
             playback_item: None,
             library: Arc::clone(&library),
+            show_track_cover: config.show_track_cover,
         });
         let playback = Playback {
             state: PlaybackState::Stopped,
@@ -372,6 +373,7 @@ impl SavedAlbums {
 pub struct CommonCtx {
     pub playback_item: Option<Arc<Track>>,
     pub library: Arc<Library>,
+    pub show_track_cover: bool,
 }
 
 impl CommonCtx {

--- a/psst-gui/src/ui/playlist.rs
+++ b/psst-gui/src/ui/playlist.rs
@@ -132,6 +132,7 @@ pub fn detail_widget() -> impl Widget<AppState> {
                     title: true,
                     artist: true,
                     album: true,
+                    cover: true,
                     ..TrackDisplay::empty()
                 },
                 cmd::FIND_IN_PLAYLIST,

--- a/psst-gui/src/ui/search.rs
+++ b/psst-gui/src/ui/search.rs
@@ -114,6 +114,7 @@ fn track_results_widget() -> impl Widget<WithCtx<SearchResults>> {
                 title: true,
                 artist: true,
                 album: true,
+                cover: true,
                 ..TrackDisplay::empty()
             })),
     )

--- a/psst-gui/src/ui/track.rs
+++ b/psst-gui/src/ui/track.rs
@@ -318,13 +318,14 @@ fn track_widget(display: TrackDisplay) -> impl Widget<TrackRow> {
     major.add_default_spacer();
     major.add_child(track_duration);
 
-    let main_columns = Flex::column()
-        .cross_axis_alignment(CrossAxisAlignment::Start)
-        .with_child(major)
-        .with_spacer(2.0)
-        .with_child(minor);
-
-    main_row.with_child(main_columns)
+    main_row.with_flex_child(
+            Flex::column()
+                .cross_axis_alignment(CrossAxisAlignment::Start)
+                .with_child(major)
+                .with_spacer(2.0)
+                .with_child(minor),
+            1.0
+        )
         .padding(theme::grid(1.0))
         .link()
         .active(|row, _| row.is_playing)


### PR DESCRIPTION
<img width="477" alt="Screen Shot 2021-12-11 at 4 38 40 PM" src="https://user-images.githubusercontent.com/61218022/145695038-3505b69e-b7b6-4161-9f1a-ce4aff9a3271.png">

This adds cover art images to tracks within playlists and search results (but not in albums), akin to the first party Spotify app (see attached image for a visual of what it looks like now). I didn't see an issue about this, but I feel it makes sense since that is what the spotify electron app does.

If you feel this is an unwanted change or should be implemented some other way, let me know and I'd be glad to discuss it :)