### PR TITLE
Navigate back when the 'back' button is pressed on mouse

### DIFF
--- a/psst-gui/src/controller/nav.rs
+++ b/psst-gui/src/controller/nav.rs
@@ -80,6 +80,11 @@ where
                 ctx.set_handled();
                 self.load_route_data(ctx, data);
             }
+            Event::MouseDown(cmd) if cmd.button.is_x1() => {
+                data.navigate_back();
+                ctx.set_handled();
+                self.load_route_data(ctx, data);
+            }
             _ => {
                 child.event(ctx, event, data, env);
             }


### PR DESCRIPTION
QoL feature that I and maybe others will find useful when navigating.
Tested on my Logitech G203 on Windows. Pressing the "down" (aka back button; aka MouseButton::X1) will navigate to the previous page in the UI.