### PR TITLE
Update souvlaki

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,12 +365,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-sha1"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb58b6451e8c2a812ad979ed1d83378caa5e927eef2622017a45f251457c2c9d"
-
-[[package]]
 name = "core-foundation"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "dbus-crossroads"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4581bbfd99f34e6864049adbe099e07c0d55c40760b23bb8e1e5d1c2ae68ca3"
+checksum = "a5d83c4b78f7c7d0dec4859d286665a06858a607ba406c91a36316ff36918141"
 dependencies = [
  "dbus",
 ]
@@ -2379,9 +2373,9 @@ dependencies = [
 
 [[package]]
 name = "souvlaki"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00d48cbf0b03cc153c8afab4de57fed0e8e9b737b7bc4a7612fc1a34322e82e"
+checksum = "2fcae98b3e396828c434032fa9a6859c4ab55f6c0441eb8e6ff1b9dcbafe4198"
 dependencies = [
  "block",
  "cocoa",
@@ -3016,30 +3010,46 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.17.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f1c7f11b289e450f78d55dd9dc09ae91c6ae8faed980bbf3e3a4c8f166ac259"
+checksum = "aac7fef12f4b59cd0a29339406cc9203ab44e440ddff6b3f5a41455349fa9cf3"
 dependencies = [
- "const-sha1",
- "windows_gen",
- "windows_macros",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
-name = "windows_gen"
-version = "0.17.2"
+name = "windows_aarch64_msvc"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f5facfb04bc84b5fcd27018266d90ce272e11f8b91745dfdd47282e8e0607e"
+checksum = "c3d027175d00b01e0cbeb97d6ab6ebe03b12330a35786cbaca5252b1c4bf5d9b"
 
 [[package]]
-name = "windows_macros"
-version = "0.17.2"
+name = "windows_i686_gnu"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c32753c378262520a4fa70c2e4389f4649e751faab2a887090567cff192d299"
-dependencies = [
- "syn",
- "windows_gen",
-]
+checksum = "8793f59f7b8e8b01eda1a652b2697d87b93097198ae85f823b969ca5b89bba58"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8602f6c418b67024be2996c512f5f995de3ba417f4c75af68401ab8756796ae4"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d615f419543e0bd7d2b3323af0d86ff19cbc4f816e6453f36a2c2ce889c354"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d95421d9ed3672c280884da53201a5c46b7b2765ca6faf34b0d71cf34a3561"
 
 [[package]]
 name = "winres"

--- a/psst-gui/Cargo.toml
+++ b/psst-gui/Cargo.toml
@@ -27,7 +27,7 @@ raw-window-handle = "0.3"
 regex = "1.5"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
-souvlaki = "=0.4.0"
+souvlaki = "0.5.0"
 time = { version = "0.3", features = ["macros", "formatting"] }
 threadpool = "1.8"
 ureq = { version = "2.1", features = ["json", "socks-proxy"] }


### PR DESCRIPTION
Upstream tracked back to dbus-crossroads in order to avoid pulling
dbus as dependency into users like psst.

Done with `cargo update -p souvlaki` after changing psst-gui/Cargo.toml

Prompted by https://github.com/jpochyla/psst/pull/218#issuecomment-1003643688