### PR TITLE
Update Fedora dependencies in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ sudo apt-get install libssl-dev libgtk-3-dev libcairo2-dev libasound2-dev
 RHEL/Fedora:
 
 ```shell
-sudo dnf install openssl-devel gtk3-devel cairo-devel
+sudo dnf install openssl-devel gtk3-devel cairo-devel alsa-lib-devel
 ```
 
 ##### Building


### PR DESCRIPTION
CPAL library requires `alsa-lib-devel` package to be installed on Fedora

https://github.com/RustAudio/cpal#cpal---cross-platform-audio-library