### PR TITLE
Stop playback on stop command

### DIFF
--- a/psst-core/src/player/mod.rs
+++ b/psst-core/src/player/mod.rs
@@ -363,6 +363,7 @@ impl Player {
 
     fn stop(&mut self) {
         self.sender.send(PlayerEvent::Stopped).unwrap();
+        self.audio_output_sink.stop();
         self.state = PlayerState::Stopped;
         self.queue.clear();
         self.consecutive_loading_failures = 0;


### PR DESCRIPTION
Currently the audio playback continues when the stop command is received in the player. To me this was quite counter-intuitive, and I think the playback should stop directly.

This adds a call to `self.audio_output_sink.stop()` when the stop-command is received.

This can easily be tested using the cli-client where "s" will not do anything.