### PR TITLE
Update 'rangemap' crate to version 1.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,16 +616,6 @@ dependencies = [
 
 [[package]]
 name = "deflate"
-version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707b6a7b384888a70c8d2e8650b3e60170dfc6a67bb4aa67b6dfca57af4bedb4"
-dependencies = [
- "adler32",
- "byteorder",
-]
-
-[[package]]
-name = "deflate"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174"
@@ -1277,16 +1267,6 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "ico"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a4b3331534254a9b64095ae60d3dc2a8225a7a70229cd5888be127cdc1f6804"
-dependencies = [
- "byteorder",
- "png 0.11.0",
-]
 
 [[package]]
 name = "ident_case"
@@ -2155,18 +2135,6 @@ dependencies = [
 
 [[package]]
 name = "png"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b0cabbbd20c2d7f06dbf015e06aad59b6ca3d9ed14848783e98af9aaf19925"
-dependencies = [
- "bitflags",
- "deflate 0.7.20",
- "inflate",
- "num-iter",
-]
-
-[[package]]
-name = "png"
 version = "0.16.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6"
@@ -2384,9 +2352,9 @@ dependencies = [
 
 [[package]]
 name = "rangemap"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4556ba17699ec8276a2e73e22c5b846666e06fe9db1228a9d4377e67b5d35fcb"
+checksum = "0ea2d559b3970fe7aa56ce7432a3702ff4b20a57b543ae08b4850ee629353ea6"
 
 [[package]]
 name = "raw-window-handle"

--- a/psst-core/Cargo.toml
+++ b/psst-core/Cargo.toml
@@ -16,7 +16,7 @@ num-traits = { version = "0.2.14" }
 parking_lot = { version = "0.12.0" }
 quick-protobuf = { version = "0.8.0" }
 rand = { version = "0.8.5" }
-rangemap = { version = "1.0.1" }
+rangemap = { version = "1.0.3" }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0.79" }
 socks = { version = "0.3.4" }


### PR DESCRIPTION
This contains a fix that will hopefully solve https://github.com/jpochyla/psst/issues/301.

Not sure what happened to those dependencies that got scrubbed from Cargo.lock -- maybe they were hanging around from a messy merge or something? :man_shrugging: 