### PR TITLE
add desktop icons to deb package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
         do
           LOGO_SIZE=$(echo "${LOGO}" | grep -oE '[[:digit:]]{2,}')
           mkdir -p "${{runner.workspace}}/pkg/usr/share/icons/hicolor/${LOGO_SIZE}x${LOGO_SIZE}/"
-          cp "./psst-gui/assets/${LOGO}" "$_"
+          cp "./psst-gui/assets/${LOGO}" "$_/psst.png"
         done
     - name: Set permissions
       run: chmod 755 ${{runner.workspace}}/pkg/usr/bin/psst-gui

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,15 @@ jobs:
       run: mkdir -p ${{runner.workspace}}/pkg/usr/bin/; mv ${{runner.workspace}}/psst-gui $_
     - name: Move desktop
       run: mkdir -p ${{runner.workspace}}/pkg/usr/share/applications/; mv .pkg/psst.desktop $_
+    - name: Add icons
+      run: |
+        LOGOS=$(cd ./psst-gui/assets/ && ls logo_*.png)
+        for LOGO in $LOGOS
+        do
+          LOGO_SIZE=$(echo "${LOGO}" | grep -oE '[[:digit:]]{2,}')
+          mkdir -p "${{runner.workspace}}/pkg/usr/share/icons/hicolor/${LOGO_SIZE}x${LOGO_SIZE}/"
+          cp "./psst-gui/assets/${LOGO}" "$_"
+        done
     - name: Set permissions
       run: chmod 755 ${{runner.workspace}}/pkg/usr/bin/psst-gui
     - name: Move license

--- a/.pkg/psst.desktop
+++ b/.pkg/psst.desktop
@@ -6,3 +6,4 @@ Name=Psst
 Terminal=false
 Type=Application
 Version=1.0
+Icon=psst.png


### PR DESCRIPTION
Hi there,

This PR adds the icons from the `assets` folder to their respective folders in the debian package (`/usr/share/icons/hicolor/...`).