### PR TITLE
feat: add support for hiding other windows in macos menu

### DIFF
--- a/psst-gui/src/ui/menu.rs
+++ b/psst-gui/src/ui/menu.rs
@@ -32,6 +32,11 @@ fn mac_app_menu() -> Menu<AppState> {
                 .command(commands::HIDE_APPLICATION)
                 .hotkey(SysMods::Cmd, "h"),
         )
+        .entry(
+            MenuItem::new(LocalizedString::new("macos-menu-hide-others").with_placeholder("Hide Others"))
+                .command(commands::HIDE_OTHERS)
+                .hotkey(SysMods::AltCmd, "h"),
+        )
 }
 
 fn edit_menu() -> Menu<AppState> {


### PR DESCRIPTION
Adds support for `⌥⌘H` to hide other windows in macOS app menu.

![Screenshot 2022-06-25 at 20 08 55](https://user-images.githubusercontent.com/54992484/175787313-4529a52a-fdb1-4303-8d9d-519e1819e45c.png)
 