### PR TITLE
Fixes panic when using with Cubeb on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2268,6 +2268,7 @@ dependencies = [
  "tempfile",
  "ureq",
  "url",
+ "windows 0.39.0",
 ]
 
 [[package]]
@@ -2699,7 +2700,7 @@ dependencies = [
  "dispatch",
  "objc",
  "raw-window-handle 0.3.4",
- "windows",
+ "windows 0.29.0",
 ]
 
 [[package]]
@@ -3379,6 +3380,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1c4bd0a50ac6020f65184721f758dba47bb9fbc2133df715ec74a237b26794a"
+dependencies = [
+ "windows_aarch64_msvc 0.39.0",
+ "windows_i686_gnu 0.39.0",
+ "windows_i686_msvc 0.39.0",
+ "windows_x86_64_gnu 0.39.0",
+ "windows_x86_64_msvc 0.39.0",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3423,6 +3437,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7711666096bd4096ffa835238905bb33fb87267910e154b18b44eaabb340f2"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3439,6 +3459,12 @@ name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "763fc57100a5f7042e3057e7e8d9bdd7860d330070251a73d003563a3bb49e1b"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3459,6 +3485,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bc7cbfe58828921e10a9f446fcaaf649204dcfe6c1ddd712c5eebae6bda1106"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3477,6 +3509,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6868c165637d653ae1e8dc4d82c25d4f97dd6605eaa8d784b5c6e0ab2a252b65"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3493,6 +3531,12 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e4d40883ae9cae962787ca76ba76390ffa29214667a111db9e0a1ad8377e809"
 
 [[package]]
 name = "winres"

--- a/psst-core/Cargo.toml
+++ b/psst-core/Cargo.toml
@@ -38,3 +38,6 @@ cubeb = { git = "https://github.com/mozilla/cubeb-rs", optional = true }
 libsamplerate = { version = "0.1.0" }
 rb = { version = "0.4.0" }
 symphonia = { version = "0.5.0", default-features = false, features = ["ogg", "vorbis", "mp3"]}
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.39.0", features = ["Win32_System_Com"], default-features = false }

--- a/psst-core/src/audio/output/cubeb.rs
+++ b/psst-core/src/audio/output/cubeb.rs
@@ -55,6 +55,13 @@ struct Stream {
 
 impl Stream {
     fn open(callback_recv: Receiver<CallbackMsg>) -> Result<Self, Error> {
+        if cfg!(target_os = "windows") {
+            // Call CoInitialize() before any other calls to the API.
+            unsafe {
+                let _ = windows::Win32::System::Com::CoInitialize(0 as *mut _);
+            };
+        }
+
         let backend_name = env::var("CUBEB_BACKEND")
             .ok()
             .and_then(|s| CString::new(s).ok());


### PR DESCRIPTION
When running with Cubeb on Windows I get an error `fatal error: hr != CO_E_NOTINITIALIZED` 

This fixes the problem by initializing COM manually.