### PR TITLE
Fix conditional compilation of windows-specific code

### DIFF
--- a/psst-core/src/audio/output/cubeb.rs
+++ b/psst-core/src/audio/output/cubeb.rs
@@ -55,12 +55,11 @@ struct Stream {
 
 impl Stream {
     fn open(callback_recv: Receiver<CallbackMsg>) -> Result<Self, Error> {
-        if cfg!(target_os = "windows") {
-            // Call CoInitialize() before any other calls to the API.
-            unsafe {
-                let _ = windows::Win32::System::Com::CoInitialize(0 as *mut _);
-            };
-        }
+        // Call CoInitialize() before any other calls to the API.
+        #[cfg(target_os = "windows")]
+        unsafe {
+            let _ = windows::Win32::System::Com::CoInitialize(0 as *mut _);
+        };
 
         let backend_name = env::var("CUBEB_BACKEND")
             .ok()


### PR DESCRIPTION
The code should be compiled out, otherwise the build will only work on windows as the windows crate becomes a hard dependency