### PR TITLE
Clear credentials from UI after authenticating

### DIFF
--- a/psst-gui/src/data/config.rs
+++ b/psst-gui/src/data/config.rs
@@ -65,6 +65,11 @@ impl Authentication {
         let connection = SessionConnection::open(config).map_err(|err| err.to_string())?;
         Ok(connection.credentials)
     }
+
+    pub fn clear(&mut self) {
+        self.username.clear();
+        self.password.clear();
+    }
 }
 
 const APP_NAME: &str = "Psst";

--- a/psst-gui/src/delegate.rs
+++ b/psst-gui/src/delegate.rs
@@ -127,6 +127,7 @@ impl AppDelegate<AppState> for Delegate {
         if self.preferences_window == Some(id) {
             self.preferences_window.take();
             data.preferences.reset();
+            data.preferences.auth.clear();
         }
         if self.main_window == Some(id) {
             ctx.submit_command(commands::CLOSE_ALL_WINDOWS);

--- a/psst-gui/src/ui/preferences.rs
+++ b/psst-gui/src/ui/preferences.rs
@@ -333,10 +333,10 @@ impl<W: Widget<AppState>> Controller<AppState, W> for Authenticate {
                             ctx.submit_command(cmd::SESSION_CONNECT);
                         }
                     }
+                    // Only clear username if login is successful.
+                    data.preferences.auth.username.clear();
                 }
-
-                // Clear the credentials from the UI.
-                data.preferences.auth.username.clear();
+                // Always clear password after login attempt.
                 data.preferences.auth.password.clear();
 
                 ctx.set_handled();

--- a/psst-gui/src/ui/preferences.rs
+++ b/psst-gui/src/ui/preferences.rs
@@ -311,6 +311,10 @@ impl<W: Widget<AppState>> Controller<AppState, W> for Authenticate {
                 // Signal the auth result to the preferences UI.
                 data.preferences.auth.result.resolve_or_reject((), result);
 
+                // Clear the credentials from the UI.
+                data.preferences.auth.username.clear();
+                data.preferences.auth.password.clear();
+
                 match &self.tab {
                     AccountTab::FirstSetup => {
                         // We let the `SessionController` pick up the credentials when the main

--- a/psst-gui/src/ui/preferences.rs
+++ b/psst-gui/src/ui/preferences.rs
@@ -311,10 +311,6 @@ impl<W: Widget<AppState>> Controller<AppState, W> for Authenticate {
                 // Signal the auth result to the preferences UI.
                 data.preferences.auth.result.resolve_or_reject((), result);
 
-                // Clear the credentials from the UI.
-                data.preferences.auth.username.clear();
-                data.preferences.auth.password.clear();
-
                 match &self.tab {
                     AccountTab::FirstSetup => {
                         // We let the `SessionController` pick up the credentials when the main
@@ -328,6 +324,10 @@ impl<W: Widget<AppState>> Controller<AppState, W> for Authenticate {
                         ctx.submit_command(cmd::SESSION_CONNECT);
                     }
                 }
+
+                // Clear the credentials from the UI.
+                data.preferences.auth.username.clear();
+                data.preferences.auth.password.clear();
 
                 ctx.set_handled();
             }


### PR DESCRIPTION
When logging in initially, or after changing accounts, until psst is restarted, when the settings panel is opened, the credentials will be visible in plain text. This clears the credentials from the UI after a login attempt, no matter if it's successful or not.

If #342 gets merged then perhaps this should only clear the credentials if authentication was successful?