### PR TITLE
Implement logging out

### DIFF
--- a/psst-gui/src/cmd.rs
+++ b/psst-gui/src/cmd.rs
@@ -15,6 +15,8 @@ pub const WIDGET_SEARCH_INPUT: WidgetId = WidgetId::reserved(1);
 // Common
 
 pub const SHOW_MAIN: Selector = Selector::new("app.show-main");
+pub const SHOW_ACCOUNT_SETUP: Selector = Selector::new("app.show-initial");
+pub const CLOSE_ALL_WINDOWS: Selector = Selector::new("app.close-all-windows");
 pub const SET_FOCUS: Selector = Selector::new("app.set-focus");
 pub const COPY: Selector<String> = Selector::new("app.copy-to-clipboard");
 
@@ -27,6 +29,7 @@ pub const FIND_IN_SAVED_TRACKS: Selector<Find> = Selector::new("find-in-saved-tr
 // Session
 
 pub const SESSION_CONNECT: Selector = Selector::new("app.session-connect");
+pub const LOG_OUT: Selector = Selector::new("app.log-out");
 
 // Navigation
 

--- a/psst-gui/src/data/config.rs
+++ b/psst-gui/src/data/config.rs
@@ -156,6 +156,10 @@ impl Config {
         self.credentials.replace(credentials);
     }
 
+    pub fn clear_credentials(&mut self) {
+        self.credentials = Default::default();
+    }
+
     pub fn username(&self) -> Option<&str> {
         self.credentials.as_ref().map(|c| c.username.as_str())
     }

--- a/psst-gui/src/delegate.rs
+++ b/psst-gui/src/delegate.rs
@@ -47,6 +47,19 @@ impl Delegate {
         }
     }
 
+    fn show_account_setup(&mut self, ctx: &mut DelegateCtx) {
+        match self.preferences_window {
+            Some(id) => {
+                ctx.submit_command(commands::SHOW_WINDOW.to(id));
+            }
+            None => {
+                let window = ui::account_setup_window();
+                self.preferences_window.replace(window.id);
+                ctx.new_window(window);
+            }
+        }
+    }
+
     fn show_preferences(&mut self, ctx: &mut DelegateCtx) {
         match self.preferences_window {
             Some(id) => {
@@ -58,6 +71,12 @@ impl Delegate {
                 ctx.new_window(window);
             }
         }
+    }
+
+    fn close_all_windows(&mut self, ctx: &mut DelegateCtx) {
+        ctx.submit_command(commands::CLOSE_ALL_WINDOWS);
+        self.main_window = None;
+        self.preferences_window = None;
     }
 }
 
@@ -73,8 +92,14 @@ impl AppDelegate<AppState> for Delegate {
         if cmd.is(cmd::SHOW_MAIN) {
             self.show_main(ctx);
             Handled::Yes
+        } else if cmd.is(cmd::SHOW_ACCOUNT_SETUP) {
+            self.show_account_setup(ctx);
+            Handled::Yes
         } else if cmd.is(commands::SHOW_PREFERENCES) {
             self.show_preferences(ctx);
+            Handled::Yes
+        } else if cmd.is(cmd::CLOSE_ALL_WINDOWS) {
+            self.close_all_windows(ctx);
             Handled::Yes
         } else if let Some(text) = cmd.get(cmd::COPY) {
             Application::global().clipboard().put_string(&text);

--- a/psst-gui/src/ui/preferences.rs
+++ b/psst-gui/src/ui/preferences.rs
@@ -248,6 +248,12 @@ fn account_tab_widget(tab: AccountTab) -> impl Widget<AppState> {
 
     col = col.with_spacer(theme::grid(3.0));
 
+    if matches!(tab, AccountTab::InPreferences) {
+        col = col.with_child(Button::new("Log Out").on_click(|ctx, _, _| {
+            ctx.submit_command(cmd::LOG_OUT);
+        }))
+    }
+
     col.controller(Authenticate::new(tab))
 }
 
@@ -325,6 +331,14 @@ impl<W: Widget<AppState>> Controller<AppState, W> for Authenticate {
                     }
                 }
 
+                ctx.set_handled();
+            }
+            Event::Command(cmd) if cmd.is(cmd::LOG_OUT) => {
+                data.config.clear_credentials();
+                data.config.save();
+                data.session.shutdown();
+                ctx.submit_command(cmd::CLOSE_ALL_WINDOWS);
+                ctx.submit_command(cmd::SHOW_ACCOUNT_SETUP);
                 ctx.set_handled();
             }
             _ => {


### PR DESCRIPTION
Adds a log-out button to the account preferences page that clears the stored credentials, closes the current session, and returns the user to the initial account setup page.