### PR TITLE
Quit app when the main window is closed

### DIFF
--- a/psst-gui/src/delegate.rs
+++ b/psst-gui/src/delegate.rs
@@ -91,14 +91,15 @@ impl AppDelegate<AppState> for Delegate {
         id: WindowId,
         data: &mut AppState,
         _env: &Env,
-        _ctx: &mut DelegateCtx,
+        ctx: &mut DelegateCtx,
     ) {
         if self.preferences_window == Some(id) {
             self.preferences_window.take();
             data.preferences.reset();
         }
         if self.main_window == Some(id) {
-            self.main_window.take();
+            ctx.submit_command(commands::CLOSE_ALL_WINDOWS);
+            ctx.submit_command(commands::QUIT_APP);
         }
     }
 }


### PR DESCRIPTION
Ensures all child windows are closed and the app closes when the main window is closed. Fixes #249.
I currently call the `CLOSE_ALL_WINDOWS` and `QUIT_APP` commands because on Windows the `QUIT_APP` command takes a while to actually quit, and I'm not sure if `CLOSE_ALL_WINDOWS` works the same way on other platforms as it does Windows. Testing on other platforms to see if both are necessary would be appreciated!