### PR TITLE
Sync native media playback progress bar on change from client

### DIFF
--- a/psst-gui/src/controller/playback.rs
+++ b/psst-gui/src/controller/playback.rs
@@ -321,6 +321,7 @@ where
             Event::Command(cmd) if cmd.is(cmd::PLAYBACK_PROGRESS) => {
                 let progress = cmd.get_unchecked(cmd::PLAYBACK_PROGRESS);
                 data.progress_playback(progress.to_owned());
+                self.update_media_control_playback(&data.playback);
                 ctx.set_handled();
             }
             Event::Command(cmd) if cmd.is(cmd::PLAYBACK_PAUSING) => {


### PR DESCRIPTION
This fixes the problem of the media player not being in-sync with changes from the Psst client. This resolves part of https://github.com/jpochyla/psst/issues/350. This does not fix the usability of the native media player progress bar, this will happen in a separate change (requires upstream change to dependency).

Before:
![psst_media_player_sync_before](https://user-images.githubusercontent.com/56088145/197250458-79a4b571-a8ac-46f4-89e8-463e82ab5305.gif)


After:
![psst_media_player_sync_after](https://user-images.githubusercontent.com/56088145/197250474-e99d295a-ee40-4e64-8c6b-5ff23052980f.gif)
