### PR TITLE
Enable native MacOS slider to control position in track

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2572,8 +2572,9 @@ dependencies = [
 
 [[package]]
 name = "souvlaki"
-version = "0.5.2"
-source = "git+https://github.com/literallyjustroy/souvlaki?branch=macos_set_position#e2c80db6adf8144d42fa92a5f4e7fcbb95c8664c"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30e432507b92ffbb7df7d07de3a0e0aa23490ee78522b679ae068eeaeba45879"
 dependencies = [
  "block",
  "cocoa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2573,8 +2573,7 @@ dependencies = [
 [[package]]
 name = "souvlaki"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b284dd0c992f84458513f4a316fb5ec0475d71c8e4fb118b40198a231f49273a"
+source = "git+https://github.com/literallyjustroy/souvlaki?branch=macos_set_position#e2c80db6adf8144d42fa92a5f4e7fcbb95c8664c"
 dependencies = [
  "block",
  "cocoa",

--- a/psst-gui/Cargo.toml
+++ b/psst-gui/Cargo.toml
@@ -41,7 +41,7 @@ druid-enums = { git = "https://github.com/luleyleo/druid-enums" }
 druid-shell = { git = "https://github.com/jpochyla/druid", branch = "psst", features = ["raw-win-handle"] }
 open = { version = "3.0.3" }
 raw-window-handle = { version = "0.5.0" }
-souvlaki = { version = "0.5.2" }
+souvlaki = { git = "https://github.com/literallyjustroy/souvlaki", branch = "macos_set_position" }
 
 [target.'cfg(windows)'.build-dependencies]
 winres = { version = "0.1.12" }

--- a/psst-gui/Cargo.toml
+++ b/psst-gui/Cargo.toml
@@ -41,7 +41,7 @@ druid-enums = { git = "https://github.com/luleyleo/druid-enums" }
 druid-shell = { git = "https://github.com/jpochyla/druid", branch = "psst", features = ["raw-win-handle"] }
 open = { version = "3.0.3" }
 raw-window-handle = { version = "0.5.0" }
-souvlaki = { git = "https://github.com/literallyjustroy/souvlaki", branch = "macos_set_position" }
+souvlaki = { version = "0.5.3" }
 
 [target.'cfg(windows)'.build-dependencies]
 winres = { version = "0.1.12" }

--- a/psst-gui/src/controller/playback.rs
+++ b/psst-gui/src/controller/playback.rs
@@ -161,7 +161,7 @@ impl PlaybackController {
             MediaControlEvent::Previous => PlayerEvent::Command(PlayerCommand::Previous),
             MediaControlEvent::SetPosition(MediaPosition(duration)) => {
                 PlayerEvent::Command(PlayerCommand::Seek { position: duration })
-            },
+            }
             _ => {
                 return;
             }

--- a/psst-gui/src/controller/playback.rs
+++ b/psst-gui/src/controller/playback.rs
@@ -159,6 +159,9 @@ impl PlaybackController {
             MediaControlEvent::Toggle => PlayerEvent::Command(PlayerCommand::PauseOrResume),
             MediaControlEvent::Next => PlayerEvent::Command(PlayerCommand::Next),
             MediaControlEvent::Previous => PlayerEvent::Command(PlayerCommand::Previous),
+            MediaControlEvent::SetPosition(MediaPosition(duration)) => {
+                PlayerEvent::Command(PlayerCommand::Seek { position: duration })
+            },
             _ => {
                 return;
             }


### PR DESCRIPTION
Update the version of [souvlaki](https://github.com/Sinono3/souvlaki) to support MacOS media progress events, and take advantage of those events. Resolves part of https://github.com/jpochyla/psst/issues/350

Before:
![psst_native_playback_before](https://user-images.githubusercontent.com/56088145/197277680-1ac08bc6-c520-4438-b7a2-2c2084b2121b.gif)

After:
![psst_native_playback_after](https://user-images.githubusercontent.com/56088145/197277636-c3f67bd6-5d81-4b58-8a1f-29e1c35a6599.gif)
