### PR TITLE
Addressing GitHub deprecation warnings in the CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         profile: minimal
         toolchain: stable
 
-    - uses: Swatinem/rust-cache@v1
+    - uses: Swatinem/rust-cache@v2
 
     - name: Update Linux Repositories
       run: sudo apt-get update

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: psst-gui
         path: ${{runner.workspace}}
@@ -128,7 +128,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: psst-deb
         path: ${{runner.workspace}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,15 +138,19 @@ jobs:
       run: |
         latest_release_appimage_url=$(wget -q https://api.github.com/repos/AppImageCommunity/pkg2appimage/releases/latest -O - | jq -r '.assets[0].browser_download_url')
         wget --directory-prefix=${{runner.workspace}}/appimage -c $latest_release_appimage_url
-    - name: grab pkg2appimage's executable name
-      id: grab_executable_name
-      run: echo "::set-output name=executable::$(ls ${{runner.workspace}}/appimage)"
-    - name: run pkg2appimage on debian package
+    - name: create absolute path to pkg2appimage's executable
       run: |
-        app=${{runner.workspace}}/appimage/${{steps.grab_executable_name.outputs.executable}}
-        recipe=${{runner.workspace}}/psst/.pkg/APPIMAGE/pkg2appimage-ingredients.yml
-        chmod +x ${app}
-        ${app} ${recipe}
+        pkg2appimage_executable=$(ls ${{runner.workspace}}/appimage)
+        app_path=${{runner.workspace}}/appimage/${pkg2appimage_executable}
+        chmod +x ${app_path}
+        echo "app_path=${app_path}" >> $GITHUB_ENV 
+    - name: create absolute path to pkg2appimage's recipe file
+      run: |
+        recipe_path=${{runner.workspace}}/psst/.pkg/APPIMAGE/pkg2appimage-ingredients.yml
+        echo "recipe_path=${recipe_path}" >> $GITHUB_ENV
+    - name: run pkg2appimage to create appimage from debian package
+      run: |
+        ${{env.app_path}} ${{env.recipe_path}}
     - uses: actions/upload-artifact@v3
       with:
         name: psst-appimage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
-        submodules: recursive 
+        submodules: recursive
 
     - uses: actions-rs/toolchain@v1
       with:
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - uses: actions/download-artifact@v2
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: deb
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - uses: actions/download-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,19 +64,19 @@ jobs:
       run: chmod +x target/release/psst-gui
       if: ${{ runner.os == 'Linux' }}
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: psst-gui
         path: target/release/psst-gui
       if: ${{ runner.os == 'Linux' }}
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: Psst-x64.dmg
         path: ./Psst-x64.dmg
       if: ${{ runner.os == 'macOS' }}
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: Psst.exe
         path: target/release/psst-gui.exe
@@ -116,7 +116,7 @@ jobs:
       run: "echo Version: $(git rev-list --count HEAD) >> ${{runner.workspace}}/pkg/DEBIAN/control"
     - name: Build package
       run: cat ${{runner.workspace}}/pkg/DEBIAN/control && dpkg-deb -b ${{runner.workspace}}/pkg/ psst_$(git rev-list --count HEAD)_amd64.deb
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: psst-deb
         path: "*.deb"
@@ -147,7 +147,7 @@ jobs:
         recipe=${{runner.workspace}}/psst/.pkg/APPIMAGE/pkg2appimage-ingredients.yml
         chmod +x ${app}
         ${app} ${recipe}
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: psst-appimage
         path: ${{runner.workspace}}/out/*.AppImage


### PR DESCRIPTION
This PR addresses some of the deprecation warnings in the CI workflow. By updating the actions in use and fixing one usage of the deprecated `::set-output` in the appimage job that I created I brought the deprecation warnings from roughly 30 down to 16 in the master branch.

The remaining 16 deprecation warnings seem to stem from the different OS images that are in use and should automatically resolve when GitHub points them to newer releases (i.e. `ubuntu-latest` currently points to ubuntu-20.04 and will pivot to ubuntu-22.04 in the near future as of https://github.blog/changelog/2022-08-09-github-actions-ubuntu-22-04-is-now-generally-available-on-github-hosted-runners/ ).
 