### PR TITLE
Fix queue behaviour when switching away from random

### DIFF
--- a/psst-core/src/player/queue.rs
+++ b/psst-core/src/player/queue.rs
@@ -61,20 +61,17 @@ impl Queue {
         // Start with an ordered 1:1 mapping.
         self.positions = (0..self.items.len()).collect();
 
-        match self.behavior {
-            QueueBehavior::Random => {
-                // Swap the current position with the first item, so we will start from the
-                // beginning, with the full queue ahead of us.  Then shuffle the rest of the
-                // items and set the position to 0.
-                if self.positions.len() > 1 {
-                    self.positions.swap(0, self.position);
-                    self.positions[1..].shuffle(&mut rand::thread_rng());
-                }
-                self.position = 0;
+        if let QueueBehavior::Random = self.behavior {
+            // Swap the current position with the first item, so we will start from the
+            // beginning, with the full queue ahead of us.  Then shuffle the rest of the
+            // items and set the position to 0.
+            if self.positions.len() > 1 {
+                self.positions.swap(0, self.position);
+                self.positions[1..].shuffle(&mut rand::thread_rng());
             }
-            _ => {
-                self.position = playlist_position;
-            }
+            self.position = 0;
+        } else {
+            self.position = playlist_position;
         }
     }
 

--- a/psst-core/src/player/queue.rs
+++ b/psst-core/src/player/queue.rs
@@ -51,18 +51,30 @@ impl Queue {
     }
 
     fn compute_positions(&mut self) {
+        // In the case of switching away from shuffle, the position should be set back to
+        // where it appears in the actual playlist order.
+        let playlist_position = if self.positions.len() > 1 {
+            self.positions[self.position]
+        } else {
+            self.position
+        };
         // Start with an ordered 1:1 mapping.
         self.positions = (0..self.items.len()).collect();
 
-        if let QueueBehavior::Random = self.behavior {
-            // Swap the current position with the first item, so we will start from the
-            // beginning, with the full queue ahead of us.  Then shuffle the rest of the
-            // items and set the position to 0.
-            if self.positions.len() > 1 {
-                self.positions.swap(0, self.position);
-                self.positions[1..].shuffle(&mut rand::thread_rng());
+        match self.behavior {
+            QueueBehavior::Random => {
+                // Swap the current position with the first item, so we will start from the
+                // beginning, with the full queue ahead of us.  Then shuffle the rest of the
+                // items and set the position to 0.
+                if self.positions.len() > 1 {
+                    self.positions.swap(0, self.position);
+                    self.positions[1..].shuffle(&mut rand::thread_rng());
+                }
+                self.position = 0;
             }
-            self.position = 0;
+            _ => {
+                self.position = playlist_position;
+            }
         }
     }
 


### PR DESCRIPTION
Playback should proceed according to the currently selected queue behaviour. The implementation of random/shuffle was causing other options to fail if it had been previously selected. 

This change restores the actual playlist position when switching queue behaviours, allowing for correct queue advancement at the end of the currently playing item.

To reproduce the original problem:
Open a playlist/album.
Select and play any item other than number 1*.
Select the random queue behaviour.
Select the loop all behaviour.
Click the skip to next item button.
When play advances to the next item, it will not be as expected (item 2 will probably play).

*The problem still exists from here, but is harder to spot.