### PR TITLE
Don't save config on each change in geometry

### DIFF
--- a/psst-gui/src/delegate.rs
+++ b/psst-gui/src/delegate.rs
@@ -129,6 +129,7 @@ impl AppDelegate<AppState> for Delegate {
             data.preferences.reset();
         }
         if self.main_window == Some(id) {
+            data.config.save();
             ctx.submit_command(commands::CLOSE_ALL_WINDOWS);
             ctx.submit_command(commands::QUIT_APP);
         }
@@ -144,7 +145,6 @@ impl AppDelegate<AppState> for Delegate {
     ) -> Option<Event> {
         if let Event::WindowSize(size) = event {
             data.config.window_size = size;
-            data.config.save();
         }
         Some(event)
     }


### PR DESCRIPTION
Changes the WindowSize event handler to not save the config on each geometry change, but rather wait until the application is closed and save it then.

I've only tested this on Linux so if someone on macOS/Windows could confirm this works as intended that'd be nice.

Closes #360.