### PR TITLE
use buffered IO when loading and saving config

### DIFF
--- a/psst-gui/src/data/config.rs
+++ b/psst-gui/src/data/config.rs
@@ -1,3 +1,4 @@
+use std::io::{BufReader, BufWriter};
 use std::{env, env::VarError, fs::File, path::PathBuf};
 
 use std::fs::OpenOptions;
@@ -137,7 +138,8 @@ impl Config {
         let path = Self::config_path().expect("Failed to get config path");
         if let Ok(file) = File::open(&path) {
             log::info!("loading config: {:?}", &path);
-            Some(serde_json::from_reader(file).expect("Failed to read config"))
+            let reader = BufReader::new(file);
+            Some(serde_json::from_reader(reader).expect("Failed to read config"))
         } else {
             None
         }
@@ -154,8 +156,9 @@ impl Config {
         options.mode(0o600);
 
         let file = options.open(&path).expect("Failed to create config");
+        let writer = BufWriter::new(file);
 
-        serde_json::to_writer_pretty(file, self).expect("Failed to write config");
+        serde_json::to_writer_pretty(writer, self).expect("Failed to write config");
         log::info!("saved config: {:?}", &path);
     }
 


### PR DESCRIPTION
As per https://docs.rs/serde_json/latest/serde_json/fn.from_reader.html

> The content of the IO stream is deserialized directly from the stream without being buffered in memory by serde_json.
> 
> When reading from a source against which short reads are not efficient, such as a [File](https://doc.rust-lang.org/std/fs/struct.File.html), you will want to apply your own buffering because serde_json will not buffer the input. See [std::io::BufReader](https://doc.rust-lang.org/std/io/struct.BufReader.html).

This is also true for `to_writer_pretty`. 

In my minimal testing, this shaved off 1000 syscalls and 15ms of the launch time. Especially reading was pretty bad as it read one byte at a time.