### PR TITLE
gui: Avoid unwrapping when fetching images

### DIFF
--- a/psst-gui/src/delegate.rs
+++ b/psst-gui/src/delegate.rs
@@ -170,13 +170,20 @@ impl Delegate {
                     .unwrap();
             } else {
                 self.image_pool.execute(move || {
-                    let image_buf = WebApi::global().get_image(location.clone()).unwrap();
-                    let payload = remote_image::ImagePayload {
-                        location,
-                        image_buf,
-                    };
-                    sink.submit_command(remote_image::PROVIDE_DATA, payload, target)
-                        .unwrap();
+                    let result = WebApi::global().get_image(location.clone());
+                    match result {
+                        Ok(image_buf) => {
+                            let payload = remote_image::ImagePayload {
+                                location,
+                                image_buf,
+                            };
+                            sink.submit_command(remote_image::PROVIDE_DATA, payload, target)
+                                .unwrap();
+                        },
+                        Err(err) => {
+                            log::warn!("failed to fetch image: {}", err)
+                        }
+                    }
                 });
             }
             Handled::Yes

--- a/psst-gui/src/delegate.rs
+++ b/psst-gui/src/delegate.rs
@@ -179,7 +179,7 @@ impl Delegate {
                             };
                             sink.submit_command(remote_image::PROVIDE_DATA, payload, target)
                                 .unwrap();
-                        },
+                        }
                         Err(err) => {
                             log::warn!("failed to fetch image: {}", err)
                         }


### PR DESCRIPTION
On bad connections, one timeout can cause the whole app to crash