### PR TITLE
Safer error-handling mechanism

### DIFF
--- a/psst-gui/src/controller/playback.rs
+++ b/psst-gui/src/controller/playback.rs
@@ -214,14 +214,14 @@ impl PlaybackController {
                 .unwrap();
         }
     }
-    
-fn send(&mut self, event: PlayerEvent) {
-    if let Some(s) = &self.sender {
-        s.send(event)
-            .map_err(|e| log::error!("Error sending message: {:?}", e))
-            .ok();
+
+    fn send(&mut self, event: PlayerEvent) {
+        if let Some(s) = &self.sender {
+            s.send(event)
+                .map_err(|e| log::error!("Error sending message: {:?}", e))
+                .ok();
+        }
     }
-}
 
     fn play(&mut self, items: &Vector<QueueEntry>, position: usize) {
         let items = items

--- a/psst-gui/src/controller/playback.rs
+++ b/psst-gui/src/controller/playback.rs
@@ -214,12 +214,12 @@ impl PlaybackController {
                 .unwrap();
         }
     }
-
+    
 fn send(&mut self, event: PlayerEvent) {
     if let Some(s) = &self.sender {
-        if let Err(e) = s.send(event) {
-            eprintln!("Error sending message: {:?}", e);
-        }
+        s.send(event)
+            .map_err(|e| log::error!("Error sending message: {:?}", e))
+            .ok();
     }
 }
 

--- a/psst-gui/src/controller/playback.rs
+++ b/psst-gui/src/controller/playback.rs
@@ -215,9 +215,13 @@ impl PlaybackController {
         }
     }
 
-    fn send(&mut self, event: PlayerEvent) {
-        self.sender.as_mut().unwrap().send(event).unwrap();
+fn send(&mut self, event: PlayerEvent) {
+    if let Some(s) = &self.sender {
+        if let Err(e) = s.send(event) {
+            eprintln!("Error sending message: {:?}", e);
+        }
     }
+}
 
     fn play(&mut self, items: &Vector<QueueEntry>, position: usize) {
         let items = items


### PR DESCRIPTION
Hi, this is my first time writing Rust, please go easy on me 🙂 Could you make sure I did it correct? I won't be offended if it's not any good. This error was I think similar to the one found in https://github.com/jpochyla/psst/pull/374

The error was as follows and it would cause the app to crash and shutdown:

> thread 'main' panicked at 'called Result::unwrap() on an Err value: "SendError(..)"', psst-gui/src/controller/playback.rs:219:51