### PR TITLE
Queue behavior & position tracking for consistency

### DIFF
--- a/psst-core/src/player/queue.rs
+++ b/psst-core/src/player/queue.rs
@@ -38,7 +38,7 @@ impl Queue {
         self.position = 0;
     }
 
-    pub fn fill(&mut self, items: &[PlaybackItem], position: usize) {
+    pub fn fill(&mut self, items: &Vec<PlaybackItem>, position: usize) {
         let items = items.to_vec();
         self.items = items;
         self.positions = (0..items.len()).collect();

--- a/psst-core/src/player/queue.rs
+++ b/psst-core/src/player/queue.rs
@@ -38,7 +38,8 @@ impl Queue {
         self.position = 0;
     }
 
-    pub fn fill(&mut self, items: Vec<PlaybackItem>, position: usize) {
+    pub fn fill(&mut self, items: &[PlaybackItem], position: usize) {
+        let items = items.to_vec();
         self.items = items;
         self.positions = (0..items.len()).collect();
         self.position = position;


### PR DESCRIPTION
Trying to improve the queue struct....  by which I mean the way it behaves during playback. So that the order of songs in the queue is consistent when switching between different playback behaviors or modifying queue. 

This fixes the following error, which makes the program unusable until restarting it:

```
thread '<unnamed>' panicked at 'index out of bounds: the len is 2 but the index is 10', 
psst-core/src/player/queue.rs:57:13 
```

With these changes it now is making sure that the positions of the songs in the queue are always tracked properly by initializing the positions vector with the original order of the items. So that the songs are always played in the right order even if the queue behavior changes. 

Also fixed a typo (behaviour -> behavior) and removed some unnecessary code.