### PR TITLE
Fixing index out of bounds error

### DIFF
--- a/psst-gui/src/controller/playback.rs
+++ b/psst-gui/src/controller/playback.rs
@@ -224,18 +224,24 @@ impl PlaybackController {
     }
 
     fn play(&mut self, items: &Vector<QueueEntry>, position: usize) {
-        let items = items
-            .iter()
-            .map(|queued| PlaybackItem {
-                item_id: queued.item.id(),
-                norm_level: match queued.origin {
-                    PlaybackOrigin::Album(_) => NormalizationLevel::Album,
-                    _ => NormalizationLevel::Track,
-                },
-            })
-            .collect();
+        let playback_items = items.iter().map(|queued| PlaybackItem {
+            item_id: queued.item.id(),
+            norm_level: match queued.origin {
+                PlaybackOrigin::Album(_) => NormalizationLevel::Album,
+                _ => NormalizationLevel::Track,
+            },
+        });
+        let playback_items_vec: Vec<PlaybackItem> = playback_items.collect();
+
+        // Make sure position is within bounds
+        let position = if position >= playback_items_vec.len() {
+            0
+        } else {
+            position
+        };
+
         self.send(PlayerEvent::Command(PlayerCommand::LoadQueue {
-            items,
+            items: playback_items_vec,
             position,
         }));
     }


### PR DESCRIPTION
Hey :+1: 

Fixed an "index out of bounds" error in the play function of playback.rs by checking that the provided position value is within bounds before sending the LoadQueue command to the player. This was the error that I kept getting, causing the app to become non-responsive until restarting it:
```
thread '<unnamed>' panicked at 'index out of bounds: the len is 2 but the index is 10', 
psst-core/src/player/queue.rs:57:13 
```
I tried modifying some things in queue.rs first but that was the wrong approach.