### PR TITLE
Add config option for the paginated items limit

### DIFF
--- a/psst-gui/src/data/config.rs
+++ b/psst-gui/src/data/config.rs
@@ -92,6 +92,7 @@ pub struct Config {
     pub slider_scroll_scale: SliderScrollScale,
     pub sort_order: SortOrder,
     pub sort_criteria: SortCriteria,
+    pub paginated_limit: usize,
 }
 
 impl Default for Config {
@@ -108,6 +109,7 @@ impl Default for Config {
             slider_scroll_scale: Default::default(),
             sort_order: Default::default(),
             sort_criteria: Default::default(),
+            paginated_limit: 500,
         }
     }
 }

--- a/psst-gui/src/main.rs
+++ b/psst-gui/src/main.rs
@@ -32,11 +32,13 @@ fn main() {
     .init();
 
     let config = Config::load().unwrap_or_default();
+    let paginated_limit = config.paginated_limit;
     let state = AppState::default_with_config(config);
     WebApi::new(
         state.session.clone(),
         Config::proxy().as_deref(),
         Config::cache_dir(),
+        paginated_limit,
     )
     .install_as_global();
 

--- a/psst-gui/src/ui/preferences.rs
+++ b/psst-gui/src/ui/preferences.rs
@@ -2,6 +2,7 @@ use std::thread::{self, JoinHandle};
 
 use druid::{
     commands,
+    text::ParseFormatter,
     widget::{
         Button, Controller, CrossAxisAlignment, Flex, Label, LineBreaking, MainAxisAlignment,
         RadioGroup, SizedBox, Slider, TextBox, ViewSwitcher,
@@ -198,6 +199,24 @@ fn general_tab_widget() -> impl Widget<AppState> {
                 )
                 .with_spacer(theme::grid(0.5))
                 .with_child(Label::new("Sensitivity")),
+        );
+
+    col = col.with_spacer(theme::grid(3.0));
+
+    col = col
+        .with_child(
+            Label::new("Max Loaded Tracks (requires restart)").with_font(theme::UI_FONT_MEDIUM),
+        )
+        .with_spacer(theme::grid(2.0))
+        .with_child(
+            Flex::row()
+                .with_child(
+                    TextBox::new().with_formatter(ParseFormatter::with_format_fn(
+                        |usize: &usize| usize.to_string(),
+                    )),
+                )
+                .padding((theme::grid(1.5), 0.0))
+                .lens(AppState::config.then(Config::paginated_limit)),
         );
 
     col

--- a/psst-gui/src/webapi/client.rs
+++ b/psst-gui/src/webapi/client.rs
@@ -39,6 +39,7 @@ pub struct WebApi {
     cache: WebApiCache,
     token_provider: TokenProvider,
     local_track_manager: Mutex<LocalTrackManager>,
+    paginated_limit: usize,
 }
 
 impl WebApi {
@@ -46,6 +47,7 @@ impl WebApi {
         session: SessionService,
         proxy_url: Option<&str>,
         cache_base: Option<PathBuf>,
+        paginated_limit: usize,
     ) -> Self {
         let agent = default_ureq_agent_builder(proxy_url).unwrap().build();
         Self {
@@ -54,6 +56,7 @@ impl WebApi {
             cache: WebApiCache::new(cache_base),
             token_provider: TokenProvider::new(),
             local_track_manager: Mutex::new(LocalTrackManager::new()),
+            paginated_limit,
         }
     }
 
@@ -158,8 +161,6 @@ impl WebApi {
     ) -> Result<(), Error> {
         // TODO: Some result sets, like very long playlists and saved tracks/albums can
         // be very big.  Implement virtualized scrolling and lazy-loading of results.
-        const PAGED_ITEMS_LIMIT: usize = 500;
-
         let mut limit = 50;
         let mut offset = 0;
         loop {
@@ -174,7 +175,7 @@ impl WebApi {
             let page_limit = page.limit;
             func(page)?;
 
-            if page_total > offset && offset < PAGED_ITEMS_LIMIT {
+            if page_total > offset && offset < self.paginated_limit {
                 limit = page_limit;
                 offset = page_offset + page_limit;
             } else {


### PR DESCRIPTION
Adds a config entry for the maximum amount of paginated items to load. Previously, this was fixed at 500, which cut off tracks in large playlists. The option's default is 500, keeping the same behavior as before.