### PR TITLE
Use Clippy for linting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libssl-dev libasound2-dev
 
       - name: Check Formatting
-        run: cargo fmt --all -- --check
+        run: cargo clippy -- -D warnings
 
   build:
     strategy:

--- a/psst-core/src/cache.rs
+++ b/psst-core/src/cache.rs
@@ -43,7 +43,7 @@ impl Cache {
 
     pub fn save_track(&self, item_id: ItemId, track: &Track) -> Result<(), Error> {
         log::debug!("saving track to cache: {:?}", item_id);
-        fs::write(self.track_path(item_id), &serialize_protobuf(track)?)?;
+        fs::write(self.track_path(item_id), serialize_protobuf(track)?)?;
         Ok(())
     }
 
@@ -61,7 +61,7 @@ impl Cache {
 
     pub fn save_episode(&self, item_id: ItemId, episode: &Episode) -> Result<(), Error> {
         log::debug!("saving episode to cache: {:?}", item_id);
-        fs::write(self.episode_path(item_id), &serialize_protobuf(episode)?)?;
+        fs::write(self.episode_path(item_id), serialize_protobuf(episode)?)?;
         Ok(())
     }
 

--- a/psst-core/src/player/storage.rs
+++ b/psst-core/src/player/storage.rs
@@ -230,7 +230,6 @@ impl StreamDataMap {
         self.requested
             .lock()
             .gaps(&(offset..offset + length))
-            .into_iter()
             .map(|r| range_to_offset_and_length(&r))
             .collect()
     }

--- a/psst-gui/build.rs
+++ b/psst-gui/build.rs
@@ -41,5 +41,5 @@ fn load_images() -> Vec<IcoFrame<'static>> {
 fn save_ico(images: &[IcoFrame<'_>], ico_path: &str) {
     let file = std::fs::File::create(ico_path).unwrap();
     let encoder = IcoEncoder::new(file);
-    encoder.encode_images(&images).unwrap();
+    encoder.encode_images(images).unwrap();
 }

--- a/psst-gui/src/data/config.rs
+++ b/psst-gui/src/data/config.rs
@@ -33,7 +33,7 @@ impl Preferences {
     }
 
     pub fn measure_cache_usage() -> Option<u64> {
-        Config::cache_dir().and_then(|path| fs_extra::dir::get_size(&path).ok())
+        Config::cache_dir().and_then(|path| fs_extra::dir::get_size(path).ok())
     }
 }
 

--- a/psst-gui/src/data/playback.rs
+++ b/psst-gui/src/data/playback.rs
@@ -62,18 +62,13 @@ impl Playable {
     }
 }
 
-#[derive(Copy, Clone, Debug, Data, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Copy, Clone, Debug, Data, Eq, PartialEq, Serialize, Deserialize)]
 pub enum QueueBehavior {
+    #[default]
     Sequential,
     Random,
     LoopTrack,
     LoopAll,
-}
-
-impl Default for QueueBehavior {
-    fn default() -> Self {
-        QueueBehavior::Sequential
-    }
 }
 
 #[derive(Copy, Clone, Debug, Data, Eq, PartialEq)]

--- a/psst-gui/src/main.rs
+++ b/psst-gui/src/main.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
-#![allow(clippy::new_without_default)]
+#![allow(clippy::new_without_default, clippy::type_complexity)]
 
 mod cmd;
 mod controller;

--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -380,11 +380,7 @@ fn topbar_sort_widget() -> impl Widget<AppState> {
     Either::new(
         |nav: &AppState, _| {
             // check if the current nav is PlaylistDetail
-            if let Nav::PlaylistDetail(_) = nav.nav {
-                true
-            } else {
-                false
-            }
+            matches!(nav.nav, Nav::PlaylistDetail(_))
         },
         enabled,
         disabled,

--- a/psst-gui/src/webapi/client.rs
+++ b/psst-gui/src/webapi/client.rs
@@ -565,7 +565,7 @@ impl WebApi {
         playlist_id: &str,
         track_uri: &str,
     ) -> Result<(), Error> {
-        self.delete(&format!("v1/playlists/{}/tracks", playlist_id))?
+        self.delete(format!("v1/playlists/{}/tracks", playlist_id))?
             .send_json(ureq::json!({
                 "tracks": [{
                     "uri": track_uri


### PR DESCRIPTION
Switches the code-style action to use Clippy instead of rustfmt, and satisfies any existing lint issues.