### PR TITLE
Add explicit label to albums

### DIFF
--- a/psst-gui/src/data/album.rs
+++ b/psst-gui/src/data/album.rs
@@ -77,6 +77,10 @@ impl Album {
             images: self.images.clone(),
         }
     }
+
+    pub fn has_explicit(&self) -> bool {
+        self.tracks.iter().any(|t| t.explicit)
+    }
 }
 
 #[derive(Clone, Debug, Data, Lens, Eq, PartialEq, Hash, Deserialize, Serialize)]

--- a/psst-gui/src/ui/album.rs
+++ b/psst-gui/src/ui/album.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use druid::{
-    widget::{CrossAxisAlignment, Flex, Label, LineBreaking, List},
+    widget::{CrossAxisAlignment, Flex, Label, LineBreaking, List, ViewSwitcher},
     LensExt, LocalizedString, Menu, MenuItem, Selector, Size, Widget, WidgetExt,
 };
 
@@ -11,7 +11,7 @@ use crate::{
         Album, AlbumDetail, AlbumLink, AppState, ArtistLink, Cached, Ctx, Library, Nav, WithCtx,
     },
     webapi::WebApi,
-    widget::{Async, MyWidgetExt, RemoteImage},
+    widget::{icons, Async, MyWidgetExt, RemoteImage},
 };
 
 use super::{artist, library, playable, theme, track, utils};
@@ -102,10 +102,21 @@ fn rounded_cover_widget(size: f64) -> impl Widget<Arc<Album>> {
 pub fn album_widget() -> impl Widget<WithCtx<Arc<Album>>> {
     let album_cover = rounded_cover_widget(theme::grid(6.0));
 
-    let album_name = Label::raw()
-        .with_font(theme::UI_FONT_MEDIUM)
-        .with_line_break_mode(LineBreaking::Clip)
-        .lens(Album::name.in_arc());
+    let album_name = Flex::row()
+        .with_child(
+            Label::raw()
+                .with_font(theme::UI_FONT_MEDIUM)
+                .with_line_break_mode(LineBreaking::Clip)
+                .lens(Album::name.in_arc()),
+        )
+        .with_spacer(theme::grid(0.5))
+        .with_child(ViewSwitcher::new(
+            |album: &Arc<Album>, _| album.has_explicit(),
+            |selector: &bool, _, _| match selector {
+                true => icons::EXPLICIT.scale(theme::ICON_SIZE_TINY).boxed(),
+                false => Box::new(Flex::column()),
+            },
+        ));
 
     let album_artists = List::new(|| {
         Label::raw()


### PR DESCRIPTION
Adds an explicit label to albums, right after the name. This was initially created to take care of #287, however, Spotify doesn't provide whether an album is explicit directly, and it doesn't return any tracks from the artist's albums endpoint, so we'll have to find another way to get that information.

![image](https://user-images.githubusercontent.com/52843537/236146201-07a931a6-c34b-4f61-b2c8-c09eeebf6108.png)
