### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,19 +631,19 @@ checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "displaydoc"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
+checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "druid"
-version = "0.8.2"
-source = "git+https://github.com/jpochyla/druid?branch=psst#bcb67b24bcecdf03f87f256c1e1da61e2ef10084"
+version = "0.8.3"
+source = "git+https://github.com/jpochyla/druid?branch=psst#230f7dd869bcab68a911f9fc05ac898e5a9b6e07"
 dependencies = [
  "console_error_panic_hook",
  "druid-derive",
@@ -665,7 +665,7 @@ dependencies = [
 [[package]]
 name = "druid-derive"
 version = "0.5.0"
-source = "git+https://github.com/jpochyla/druid?branch=psst#bcb67b24bcecdf03f87f256c1e1da61e2ef10084"
+source = "git+https://github.com/jpochyla/druid?branch=psst#230f7dd869bcab68a911f9fc05ac898e5a9b6e07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -686,8 +686,8 @@ dependencies = [
 
 [[package]]
 name = "druid-shell"
-version = "0.8.0"
-source = "git+https://github.com/jpochyla/druid?branch=psst#bcb67b24bcecdf03f87f256c1e1da61e2ef10084"
+version = "0.8.3"
+source = "git+https://github.com/jpochyla/druid?branch=psst#230f7dd869bcab68a911f9fc05ac898e5a9b6e07"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1579,9 +1579,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b64f40e5e03e0d54f03845c8197d0291253cdbedfb1cb46b13c2c117554a9f4c"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "lock_api"
@@ -2106,9 +2106,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "platform-dirs"
@@ -2449,9 +2449,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.18"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bbfc1d1c7c40c01715f47d71444744a81669ca84e8b63e25a55e169b1f86433"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
  "bitflags",
  "errno",
@@ -2518,18 +2518,18 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3497,9 +3497,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5617da7e1f97bf363947d767b91aaf3c2bbc19db7fda9c65af1278713d58e0a2"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
 dependencies = [
  "memchr",
 ]

--- a/psst-core/Cargo.toml
+++ b/psst-core/Cargo.toml
@@ -18,7 +18,7 @@ parking_lot = { version = "0.12.1" }
 quick-protobuf = { version = "0.8.1" }
 rand = { version = "0.8.5" }
 rangemap = { version = "1.3.0" }
-serde = { version = "1.0.160", features = ["derive"] }
+serde = { version = "1.0.162", features = ["derive"] }
 serde_json = { version = "1.0.96" }
 socks = { version = "0.3.4" }
 tempfile = { version = "3.5.0" }

--- a/psst-gui/Cargo.toml
+++ b/psst-gui/Cargo.toml
@@ -27,7 +27,7 @@ parking_lot = { version = "0.12.1" }
 platform-dirs = { version = "0.3.0" }
 rand = { version = "0.8.5" }
 regex = { version = "1.8.1" }
-serde = { version = "1.0.160", features = ["derive", "rc"] }
+serde = { version = "1.0.162", features = ["derive", "rc"] }
 serde_json = { version = "1.0.96" }
 threadpool = { version = "1.8.1" }
 time = { version = "0.3.20", features = ["macros", "formatting"] }


### PR DESCRIPTION
Updates serde to 1.0.162, and our fork of druid to the latest master which includes a fix for window titlebar's being opposite of the OS theme on Windows.

Closes #153.