### PR TITLE
Split playlist & control section

### DIFF
--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -42,7 +42,7 @@ pub mod utils;
 pub fn main_window(config: &Config) -> WindowDesc<AppState> {
     let win = WindowDesc::new(root_widget())
         .title(compute_main_window_title)
-        .with_min_size((theme::grid(65.0), theme::grid(46.0)))
+        .with_min_size((theme::grid(65.0), theme::grid(50.0)))
         .window_size(config.window_size)
         .show_title(false)
         .transparent_titlebar(true);

--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -42,7 +42,7 @@ pub mod utils;
 pub fn main_window(config: &Config) -> WindowDesc<AppState> {
     let win = WindowDesc::new(root_widget())
         .title(compute_main_window_title)
-        .with_min_size((theme::grid(65.0), theme::grid(50.0)))
+        .with_min_size((theme::grid(65.0), theme::grid(65.0)))
         .window_size(config.window_size)
         .show_title(false)
         .transparent_titlebar(true);
@@ -130,13 +130,13 @@ fn root_widget() -> impl Widget<AppState> {
         .with_child(volume_slider())
         .with_default_spacer()
         .with_child(user::user_widget())
-        .center();
+        .center()
+        .fix_height(100.0)
+        .background(Border::Top.with_color(theme::GREY_500));
 
-    let sidebar = Split::rows(playlists, controls)
-        .split_point(0.85)
-        .bar_size(1.0)
-        .min_bar_area(1.0)
-        .solid_bar(true)
+    let sidebar = Flex::column()
+        .with_flex_child(playlists, 1.0)
+        .with_child(controls)
         .background(theme::BACKGROUND_DARK);
 
     let topbar = Flex::row()

--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -42,7 +42,7 @@ pub mod utils;
 pub fn main_window(config: &Config) -> WindowDesc<AppState> {
     let win = WindowDesc::new(root_widget())
         .title(compute_main_window_title)
-        .with_min_size((theme::grid(65.0), theme::grid(25.0)))
+        .with_min_size((theme::grid(65.0), theme::grid(50.0)))
         .window_size(config.window_size)
         .show_title(false)
         .transparent_titlebar(true);

--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -111,21 +111,31 @@ fn root_widget() -> impl Widget<AppState> {
     let playlists = Scroll::new(playlist::list_widget())
         .vertical()
         .expand_height();
-    let sidebar = Flex::column()
+
+    let playlists = Flex::column()
         .must_fill_main_axis(true)
         .with_child(sidebar_logo_widget())
         .with_child(sidebar_menu_widget())
         .with_default_spacer()
         .with_flex_child(playlists, 1.0)
-        .with_child(volume_slider())
-        .with_default_spacer()
-        .with_child(user::user_widget())
         .padding(if cfg!(target_os = "macos") {
             // Accommodate the window controls on Mac.
             Insets::new(0.0, 24.0, 0.0, 0.0)
         } else {
             Insets::ZERO
-        })
+        });
+
+    let controls = Flex::column()
+        .with_default_spacer()
+        .with_child(volume_slider())
+        .with_default_spacer()
+        .with_child(user::user_widget());
+
+    let sidebar = Split::rows(playlists, controls)
+        .split_point(0.9)
+        .bar_size(1.0)
+        .min_bar_area(1.0)
+        .solid_bar(true)
         .background(theme::BACKGROUND_DARK);
 
     let topbar = Flex::row()

--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -129,10 +129,11 @@ fn root_widget() -> impl Widget<AppState> {
         .with_default_spacer()
         .with_child(volume_slider())
         .with_default_spacer()
-        .with_child(user::user_widget());
+        .with_child(user::user_widget())
+        .center();
 
     let sidebar = Split::rows(playlists, controls)
-        .split_point(0.9)
+        .split_point(0.85)
         .bar_size(1.0)
         .min_bar_area(1.0)
         .solid_bar(true)

--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -42,7 +42,7 @@ pub mod utils;
 pub fn main_window(config: &Config) -> WindowDesc<AppState> {
     let win = WindowDesc::new(root_widget())
         .title(compute_main_window_title)
-        .with_min_size((theme::grid(65.0), theme::grid(65.0)))
+        .with_min_size((theme::grid(65.0), theme::grid(46.0)))
         .window_size(config.window_size)
         .show_title(false)
         .transparent_titlebar(true);

--- a/psst-gui/src/ui/user.rs
+++ b/psst-gui/src/ui/user.rs
@@ -48,14 +48,14 @@ pub fn user_widget() -> impl Widget<AppState> {
             Flex::column()
                 .with_child(is_connected)
                 .with_child(user_profile)
-                .padding((theme::grid(2.0), theme::grid(2.0))),
+                .padding((theme::grid(2.0), theme::grid(1.5))),
         )
         .with_child(preferences_widget(&icons::PREFERENCES))
 }
 
 fn preferences_widget<T: Data>(svg: &SvgIcon) -> impl Widget<T> {
     svg.scale((theme::grid(3.0), theme::grid(3.0)))
-        .padding(theme::grid(2.0))
+        .padding(theme::grid(1.0))
         .link()
         .rounded(theme::BUTTON_BORDER_RADIUS)
         .on_left_click(|ctx, _, _, _| ctx.submit_command(commands::SHOW_PREFERENCES))


### PR DESCRIPTION
This adds proper spacing between the volume control and divider and splits the playlist section and volume/controls section to provide a divider.

Here an image of this PR (left) and before (right):

<img width="500" alt="Screen Shot 2023-05-09 at 9 00 42 PM" src="https://github.com/jpochyla/psst/assets/54308792/b1c9aa1d-40a4-4f52-9ab0-949a384b5155">

This also:
- Reduces padding around gear
- Increases the minimum height of window so that playlists can be visible at min height
