### PR TITLE
Fix the window getting smaller each time it's opened

### DIFF
--- a/psst-gui/src/delegate.rs
+++ b/psst-gui/src/delegate.rs
@@ -16,6 +16,7 @@ pub struct Delegate {
     main_window: Option<WindowId>,
     preferences_window: Option<WindowId>,
     image_pool: ThreadPool,
+    size_updated: bool,
 }
 
 impl Delegate {
@@ -26,6 +27,7 @@ impl Delegate {
             main_window: None,
             preferences_window: None,
             image_pool: ThreadPool::with_name("image_loading".into(), MAX_IMAGE_THREADS),
+            size_updated: false,
         }
     }
 
@@ -150,7 +152,12 @@ impl AppDelegate<AppState> for Delegate {
     ) -> Option<Event> {
         if self.main_window == Some(window_id) {
             if let Event::WindowSize(size) = event {
-                data.config.window_size = size;
+                // This is a little hacky, but without it, the window will slowly get smaller each time the application is opened.
+                if !self.size_updated {
+                    self.size_updated = true;
+                } else {
+                    data.config.window_size = size;
+                }
             }
         }
         Some(event)


### PR DESCRIPTION
When the window is created, there's an initial WindowSize event that's slightly smaller than the desired window size. This causes the app to keep getting smaller each time it's opened until it's hit the minimum window size. This makes it so the first WindowSize event doesn't save its size to the config.