### PR TITLE
Update cargo edition & linting fix

### DIFF
--- a/psst-cli/Cargo.toml
+++ b/psst-cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "psst-cli"
 version = "0.1.0"
 authors = ["Jan Pochyla <jpochyla@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [features]
 default = ["cpal"]

--- a/psst-gui/Cargo.toml
+++ b/psst-gui/Cargo.toml
@@ -2,7 +2,7 @@
 name = "psst-gui"
 version = "0.1.0"
 authors = ["Jan Pochyla <jpochyla@gmail.com>"]
-edition = "2018"
+edition = "2021"
 build = "build.rs"
 description = "Fast Spotify client with native GUI"
 repository = "https://github.com/jpochyla/psst"
@@ -60,7 +60,7 @@ icon = [
 ]
 version = "0.1.0"
 resources = []
-copyright = "Copyright (c) Jan Pochyla 2021. All rights reserved."
+copyright = "Copyright (c) Jan Pochyla 2023. All rights reserved."
 category = "Music"
 short_description = "Fast Spotify client with native GUI"
 long_description = """

--- a/psst-gui/src/controller/nav.rs
+++ b/psst-gui/src/controller/nav.rs
@@ -121,12 +121,7 @@ where
             ctx.submit_command(cmd::NAVIGATE.with(Nav::SavedTracks));
             // Load the last route, or the default.
             ctx.submit_command(
-                cmd::NAVIGATE.with(
-                    data.config
-                        .last_route
-                        .to_owned()
-                        .unwrap_or(Default::default()),
-                ),
+                cmd::NAVIGATE.with(data.config.last_route.to_owned().unwrap_or_default()),
             );
         }
         child.lifecycle(ctx, event, data, env)

--- a/psst-protocol/Cargo.toml
+++ b/psst-protocol/Cargo.toml
@@ -2,7 +2,7 @@
 name = "psst-protocol"
 version = "0.1.0"
 authors = ["Jan Pochyla <jpochyla@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 quick-protobuf = "0.8.0"


### PR DESCRIPTION
Bump the years and fix a small linting suggestion around `.unwrap_or(Default::default()),`