### PR TITLE
Adds change to clear playlist position when changing to different playlist

### DIFF
--- a/psst-core/src/player/queue.rs
+++ b/psst-core/src/player/queue.rs
@@ -40,6 +40,7 @@ impl Queue {
     }
 
     pub fn fill(&mut self, items: Vec<PlaybackItem>, position: usize) {
+        self.positions.clear();
         self.items = items;
         self.position = position;
         self.compute_positions();


### PR DESCRIPTION
A very simple addition to solve the bug related to issue #420 in which an out of bounds error was appearing due to playlist lengths not getting recalculated upon switching playlist.