### PR TITLE
fix: clears playlist positions to zero before recalculating on changing playlist (fix #420)

### DIFF
--- a/psst-core/src/player/queue.rs
+++ b/psst-core/src/player/queue.rs
@@ -40,6 +40,7 @@ impl Queue {
     }
 
     pub fn fill(&mut self, items: Vec<PlaybackItem>, position: usize) {
+        self.positions.clear();
         self.items = items;
         self.position = position;
         self.compute_positions();


### PR DESCRIPTION
This is a tiny change to fix the bug mention in issue #420 whereby an out of bounds error appears due to playlist lengths not being returned to zero upon changing to a different playlist.