### PR TITLE
Refactor the build file

### DIFF
--- a/psst-gui/build.rs
+++ b/psst-gui/build.rs
@@ -9,37 +9,34 @@ fn main() {
         let mut res = winres::WindowsResource::new();
         res.set_icon(ico_path);
         res.compile().expect("Could not attach exe icon");
-    }
-}
 
-#[cfg(windows)]
-use image::{
-    codecs::ico::{IcoEncoder, IcoFrame},
-    ColorType,
-};
+        use image::{
+            codecs::ico::{IcoEncoder, IcoFrame},
+            ColorType,
+        };
 
-#[cfg(windows)]
-fn load_images() -> Vec<IcoFrame<'static>> {
-    let sizes = vec![32, 64, 128, 256];
-    sizes
-        .iter()
-        .map(|s| {
-            IcoFrame::as_png(
-                image::open(format!("assets/logo_{}.png", s))
+        fn load_images() -> Vec<IcoFrame<'static>> {
+            let sizes = vec![32, 64, 128, 256];
+            sizes
+                .iter()
+                .map(|s| {
+                    IcoFrame::as_png(
+                        image::open(format!("assets/logo_{}.png", s))
+                            .unwrap()
+                            .as_bytes(),
+                        *s,
+                        *s,
+                        ColorType::Rgba8,
+                    )
                     .unwrap()
-                    .as_bytes(),
-                *s,
-                *s,
-                ColorType::Rgba8,
-            )
-            .unwrap()
-        })
-        .collect()
-}
+                })
+                .collect()
+        }
 
-#[cfg(windows)]
-fn save_ico(images: &[IcoFrame<'_>], ico_path: &str) {
-    let file = std::fs::File::create(ico_path).unwrap();
-    let encoder = IcoEncoder::new(file);
-    encoder.encode_images(images).unwrap();
+        fn save_ico(images: &[IcoFrame<'_>], ico_path: &str) {
+            let file = std::fs::File::create(ico_path).unwrap();
+            let encoder = IcoEncoder::new(file);
+            encoder.encode_images(images).unwrap();
+        }
+    }
 }


### PR DESCRIPTION
Moved all windows-specific build code inside one block, makes it easier to read / code fold