### PR TITLE
Remove the rust-toolchain action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
 
-      - name: Setup Toolchain
-        uses: dtolnay/rust-toolchain@stable
-
       - name: Setup Cache
         uses: Swatinem/rust-cache@v2
 
@@ -38,9 +35,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
-
-      - name: Setup Toolchain
-        uses: dtolnay/rust-toolchain@stable
 
       - name: Setup Cache
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Rust is [pre-installed on GitHub-hosted runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#preinstalled-software), so there's no need for us to have an action to install it explicitly.