### PR TITLE
Increase timeout when using proxy

### DIFF
--- a/psst-core/src/util.rs
+++ b/psst-core/src/util.rs
@@ -5,9 +5,9 @@ use quick_protobuf::{BytesReader, MessageRead, MessageWrite, Writer};
 
 use crate::error::Error;
 
-pub const NET_CONNECT_TIMEOUT: Duration = Duration::from_millis(8 * 1000);
+pub const NET_CONNECT_TIMEOUT: Duration = Duration::from_millis(16 * 1000);
 
-pub const NET_IO_TIMEOUT: Duration = Duration::from_millis(8 * 1000);
+pub const NET_IO_TIMEOUT: Duration = Duration::from_millis(16 * 1000);
 
 pub fn default_ureq_agent_builder(proxy_url: Option<&str>) -> Result<ureq::AgentBuilder, Error> {
     let builder = ureq::AgentBuilder::new()


### PR DESCRIPTION
On large playlists and/or high-latency networks there is not enough time for all album covers to finish downloading. 

> WARN  psst_gui::delegate] failed to fetch image: https://i.scdn.co/image/... Connection Failed: tls connection init failed: Resource temporarily unavailable (os error 11)

Thank you :smiley: 