### PR TITLE
Use the v2 crate resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "psst-protocol",
     "psst-core",


### PR DESCRIPTION
While v2 is the default in the 2021 edition, it's disabled by default in virtual workspaces, so we have to explicitly define it.