### PR TITLE
Makes Sidebar/Main_view split resizable

### DIFF
--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -158,7 +158,8 @@ fn root_widget() -> impl Widget<AppState> {
         .bar_size(1.0)
         .min_size(150.0, 300.0)
         .min_bar_area(1.0)
-        .solid_bar(true);
+        .solid_bar(true)
+        .draggable(true);
 
     ThemeScope::new(split)
         .controller(SessionController)


### PR DESCRIPTION
I use a tilling window manager and it throws me off how large the sidebar is because of the window occupying the whole screen. Makes the split between the sidebar and the main view draggable so it can be resized.