### PR TITLE
Adding support for Universal Binary for MacOS on M1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,17 +55,17 @@ jobs:
         run: |
           rustup target add aarch64-apple-darwin
           cargo build --release --target aarch64-apple-darwin
-      
-      - name: Building universal Binay
-        if: ${{ runner.os == 'macOS' }}
-        run: lipo target/release/psst-gui target/aarch64-apple-darwin/release/psst-gui -create -output target/release/psst-gui
-    
+          
       - name: Bundle macOS Release
         if: ${{ runner.os == 'macOS' }}
         run: |
           cargo install cargo-bundle
           cargo bundle --release
         working-directory: psst-gui
+      
+      - name: replacing binary with universal binary
+        if: ${{ runner.os == 'macOS' }}
+        run: lipo target/release/psst-gui target/aarch64-apple-darwin/release/psst-gui -create -output target/release/bundle/osx/Psst.app/Contents/MacOS/psst-gui
 
       - name: Create macOS Disk Image
         if: ${{ runner.os == 'macOS' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Bundle macOS Release
         if: ${{ runner.os == 'macOS' }}
         run: |
+          rustup target add aarch64-apple-darwin
+          cargo build --release --target aarch64-apple-darwin
+          lipo target/release/psst-gui target/aarch64-apple-darwin/release/psst-gui -create -output target/release/psst-gui
           cargo install cargo-bundle
           cargo bundle --release
         working-directory: psst-gui

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
         if: ${{ runner.os == 'macOS' }}
         run: |
           hdiutil create Psst-uncompressed.dmg -volname "Psst" -srcfolder target/release/bundle/osx
-          hdiutil convert Psst-uncompressed.dmg -format UDZO -o Psst-x64.dmg
+          hdiutil convert Psst-uncompressed.dmg -format UDZO -o Psst.dmg
 
       - name: Make Linux Binary Executable
         if: ${{ runner.os == 'Linux' }}
@@ -88,8 +88,8 @@ jobs:
         uses: actions/upload-artifact@v3
         if: ${{ runner.os == 'macOS' }}
         with:
-          name: Psst-x64.dmg
-          path: ./Psst-x64.dmg
+          name: Psst.dmg
+          path: ./Psst.dmg
 
       - name: Upload Windows Executable
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
           cargo bundle --release
         working-directory: psst-gui
       
-      - name: replacing binary with universal binary
+      - name: Create macOS universal binary
         if: ${{ runner.os == 'macOS' }}
         run: lipo target/release/psst-gui target/aarch64-apple-darwin/release/psst-gui -create -output target/release/bundle/osx/Psst.app/Contents/MacOS/psst-gui
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,12 +49,16 @@ jobs:
 
       - name: Build Release
         run: cargo build --release
-
-      - name: Bundle macOS Release
+      
+      - name: Build aarch64 for MacOS
         if: ${{ runner.os == 'macOS' }}
         run: |
           rustup target add aarch64-apple-darwin
           cargo build --release --target aarch64-apple-darwin
+      
+      - name: Bundle macOS Release
+        if: ${{ runner.os == 'macOS' }}
+        run: |
           lipo target/release/psst-gui target/aarch64-apple-darwin/release/psst-gui -create -output target/release/psst-gui
           cargo install cargo-bundle
           cargo bundle --release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,10 +56,13 @@ jobs:
           rustup target add aarch64-apple-darwin
           cargo build --release --target aarch64-apple-darwin
       
+      - name: Building universal Binay
+        if: ${{ runner.os == 'macOS' }}
+        run: lipo target/release/psst-gui target/aarch64-apple-darwin/release/psst-gui -create -output target/release/psst-gui
+    
       - name: Bundle macOS Release
         if: ${{ runner.os == 'macOS' }}
         run: |
-          lipo target/release/psst-gui target/aarch64-apple-darwin/release/psst-gui -create -output target/release/psst-gui
           cargo install cargo-bundle
           cargo bundle --release
         working-directory: psst-gui

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can download the prebuilt binaries for x86_64 Windows, Linux (Ubuntu), and m
 | [Windows](https://nightly.link/jpochyla/psst/workflows/build/master/Psst.exe.zip) |
 | [Linux (Ubuntu)](https://nightly.link/jpochyla/psst/workflows/build/master/psst-gui.zip) |
 | [Debian Package](https://nightly.link/jpochyla/psst/workflows/build/master/psst-deb.zip) |
-| [MacOS](https://nightly.link/jpochyla/psst/workflows/build/master/Psst-x64.dmg.zip) |
+| [MacOS](https://nightly.link/jpochyla/psst/workflows/build/master/Psst.dmg.zip) |
 
 Unofficial builds of Psst are also available through the [AUR](https://aur.archlinux.org/packages/psst-git) and [Homebrew](https://formulae.brew.sh/cask/psst).
 


### PR DESCRIPTION
I added support for universal binaries. The dmg contains an .app which runs native on aarch64 and x86 architecture. I tested it on my M1.
<img width="887" alt="image" src="https://github.com/jpochyla/psst/assets/6866008/2da15e3c-18d1-4be5-baef-c78d0d41159d">
