### PR TITLE
Add ability to add to queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ cargo bundle --release
     - Reorder tracks
     - Rename playlist
     - Playlist folders
-- [ ] Playback queue
+- [x] Playback queue
 - [ ] React to audio output device events
     - Pause after disconnecting headphones
     - Transfer playback after connecting headphones

--- a/psst-core/src/player/mod.rs
+++ b/psst-core/src/player/mod.rs
@@ -119,6 +119,7 @@ impl Player {
             PlayerCommand::Seek { position } => self.seek(position),
             PlayerCommand::Configure { config } => self.configure(config),
             PlayerCommand::SetQueueBehavior { behavior } => self.queue.set_behaviour(behavior),
+            PlayerCommand::AddToQueue { item } => self.queue.add(item),
             PlayerCommand::SetVolume { volume } => self.set_volume(volume),
         }
     }
@@ -282,7 +283,7 @@ impl Player {
             loading_handle,
         };
     }
-
+    
     fn set_volume(&mut self, volume: f64) {
         self.audio_output_sink.set_volume(volume as f32);
     }
@@ -421,6 +422,9 @@ pub enum PlayerCommand {
     },
     SetQueueBehavior {
         behavior: QueueBehavior,
+    },
+    AddToQueue{
+        item: PlaybackItem,
     },
     /// Change playback volume to a value in 0.0..=1.0 range.
     SetVolume {

--- a/psst-core/src/player/mod.rs
+++ b/psst-core/src/player/mod.rs
@@ -283,7 +283,7 @@ impl Player {
             loading_handle,
         };
     }
-    
+
     fn set_volume(&mut self, volume: f64) {
         self.audio_output_sink.set_volume(volume as f32);
     }
@@ -423,7 +423,7 @@ pub enum PlayerCommand {
     SetQueueBehavior {
         behavior: QueueBehavior,
     },
-    AddToQueue{
+    AddToQueue {
         item: PlaybackItem,
     },
     /// Change playback volume to a value in 0.0..=1.0 range.

--- a/psst-core/src/player/queue.rs
+++ b/psst-core/src/player/queue.rs
@@ -54,10 +54,14 @@ impl Queue {
         self.user_added_items.push(item);
     }
 
-    fn handle_added_queue(&mut self){
+    fn handle_added_queue(&mut self) {
         if self.user_added_items.len() > self.user_added_items_position {
-            self.items.insert(self.positions.len(), self.user_added_items[self.user_added_items_position]);
-            self.positions.insert(self.position + 1, self.positions.len());
+            self.items.insert(
+                self.positions.len(),
+                self.user_added_items[self.user_added_items_position],
+            );
+            self.positions
+                .insert(self.position + 1, self.positions.len());
             self.user_added_items_position += 1;
         }
     }

--- a/psst-core/src/player/queue.rs
+++ b/psst-core/src/player/queue.rs
@@ -18,9 +18,9 @@ impl Default for QueueBehavior {
 
 pub struct Queue {
     items: Vec<PlaybackItem>,
-    added_items: Vec<PlaybackItem>,
+    user_added_items: Vec<PlaybackItem>,
     position: usize,
-    added_items_position: usize,
+    user_added_items_position: usize,
     positions: Vec<usize>,
     behavior: QueueBehavior,
 }
@@ -29,9 +29,9 @@ impl Queue {
     pub fn new() -> Self {
         Self {
             items: Vec::new(),
-            added_items: Vec::new(),
+            user_added_items: Vec::new(),
             position: 0,
-            added_items_position: 0,
+            user_added_items_position: 0,
             positions: Vec::new(),
             behavior: QueueBehavior::default(),
         }
@@ -51,19 +51,14 @@ impl Queue {
     }
 
     pub fn add(&mut self, item: PlaybackItem) {
-        self.added_items.push(item);
+        self.user_added_items.push(item);
     }
 
     fn handle_added_queue(&mut self){
-        if self.added_items.len() > self.added_items_position {
-            self.items.insert(self.positions.len(), self.added_items[self.added_items_position]);
+        if self.user_added_items.len() > self.user_added_items_position {
+            self.items.insert(self.positions.len(), self.user_added_items[self.user_added_items_position]);
             self.positions.insert(self.position + 1, self.positions.len());
-            self.added_items_position += 1;
-            
-            if self.added_items_position > 2 {
-                self.added_items.remove(0);
-                self.added_items_position -= 1;
-        }
+            self.user_added_items_position += 1;
         }
     }
 
@@ -122,7 +117,7 @@ impl Queue {
                 return Some(item);
             }
         } else {
-            return self.added_items.get(0);
+            return self.user_added_items.first();
         }
         None
     }

--- a/psst-core/src/player/queue.rs
+++ b/psst-core/src/player/queue.rs
@@ -18,9 +18,9 @@ impl Default for QueueBehavior {
 
 pub struct Queue {
     items: Vec<PlaybackItem>,
-    user_added_items: Vec<PlaybackItem>,
+    user_items: Vec<PlaybackItem>,
     position: usize,
-    user_added_items_position: usize,
+    user_items_position: usize,
     positions: Vec<usize>,
     behavior: QueueBehavior,
 }
@@ -29,9 +29,9 @@ impl Queue {
     pub fn new() -> Self {
         Self {
             items: Vec::new(),
-            user_added_items: Vec::new(),
+            user_items: Vec::new(),
             position: 0,
-            user_added_items_position: 0,
+            user_items_position: 0,
             positions: Vec::new(),
             behavior: QueueBehavior::default(),
         }
@@ -51,18 +51,18 @@ impl Queue {
     }
 
     pub fn add(&mut self, item: PlaybackItem) {
-        self.user_added_items.push(item);
+        self.user_items.push(item);
     }
 
     fn handle_added_queue(&mut self) {
-        if self.user_added_items.len() > self.user_added_items_position {
+        if self.user_items.len() > self.user_items_position {
             self.items.insert(
                 self.positions.len(),
-                self.user_added_items[self.user_added_items_position],
+                self.user_items[self.user_items_position],
             );
             self.positions
                 .insert(self.position + 1, self.positions.len());
-            self.user_added_items_position += 1;
+            self.user_items_position += 1;
         }
     }
 
@@ -121,7 +121,7 @@ impl Queue {
                 return Some(item);
             }
         } else {
-            return self.user_added_items.first();
+            return self.user_items.first();
         }
         None
     }

--- a/psst-core/src/player/queue.rs
+++ b/psst-core/src/player/queue.rs
@@ -56,15 +56,14 @@ impl Queue {
 
     fn handle_added_queue(&mut self){
         if self.added_items.len() > self.added_items_position {
-            self.compute_positions();
-            self.items.insert(0, self.added_items[self.added_items_position]);
-            self.positions.insert(self.position + 1, 0);
+            self.items.insert(self.positions.len(), self.added_items[self.added_items_position]);
+            self.positions.insert(self.position + 1, self.positions.len());
             self.added_items_position += 1;
             
-            // Remove the past song from the queue as otherwise the queue will just go on for ever.
             if self.added_items_position > 2 {
                 self.added_items.remove(0);
-            }
+                self.added_items_position -= 1;
+        }
         }
     }
 

--- a/psst-core/src/player/queue.rs
+++ b/psst-core/src/player/queue.rs
@@ -46,6 +46,21 @@ impl Queue {
         self.compute_positions();
     }
 
+    pub fn add(&mut self, item: PlaybackItem) {
+        match self.behavior {
+            QueueBehavior::Random => {
+                self.compute_positions();
+                self.items.insert(0, item);
+                self.positions.insert(self.position + 1, 0);
+            }
+            _ => {
+                // For other modes, insert the item at the current position + 1
+                self.items.insert(self.position + 1, item);
+            }
+        }
+    }
+    
+
     pub fn set_behaviour(&mut self, behavior: QueueBehavior) {
         self.behavior = behavior;
         self.compute_positions();

--- a/psst-gui/src/cmd.rs
+++ b/psst-gui/src/cmd.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use druid::{Selector, WidgetId};
-use psst_core::item_id::ItemId;
+use psst_core::{item_id::ItemId, player::item::PlaybackItem};
 
 use crate::{
     data::{Nav, PlaybackPayload, QueueBehavior},
@@ -56,6 +56,7 @@ pub const PLAY_PAUSE: Selector = Selector::new("app.play-pause");
 pub const PLAY_RESUME: Selector = Selector::new("app.play-resume");
 pub const PLAY_NEXT: Selector = Selector::new("app.play-next");
 pub const PLAY_STOP: Selector = Selector::new("app.play-stop");
+pub const ADD_TO_QUEUE: Selector<PlaybackItem> = Selector::new("app.add-to-queue");
 pub const PLAY_QUEUE_BEHAVIOR: Selector<QueueBehavior> = Selector::new("app.play-queue-behavior");
 pub const PLAY_SEEK: Selector<f64> = Selector::new("app.play-seek");
 

--- a/psst-gui/src/cmd.rs
+++ b/psst-gui/src/cmd.rs
@@ -4,7 +4,7 @@ use druid::{Selector, WidgetId};
 use psst_core::{item_id::ItemId, player::item::PlaybackItem};
 
 use crate::{
-    data::{Nav, PlaybackPayload, QueueBehavior},
+    data::{Nav, PlaybackPayload, PlaylistTracks, QueueBehavior, QueueEntry},
     ui::find::Find,
 };
 
@@ -56,7 +56,7 @@ pub const PLAY_PAUSE: Selector = Selector::new("app.play-pause");
 pub const PLAY_RESUME: Selector = Selector::new("app.play-resume");
 pub const PLAY_NEXT: Selector = Selector::new("app.play-next");
 pub const PLAY_STOP: Selector = Selector::new("app.play-stop");
-pub const ADD_TO_QUEUE: Selector<PlaybackItem> = Selector::new("app.add-to-queue");
+pub const ADD_TO_QUEUE: Selector<(QueueEntry, PlaybackItem)> = Selector::new("app.add-to-queue");
 pub const PLAY_QUEUE_BEHAVIOR: Selector<QueueBehavior> = Selector::new("app.play-queue-behavior");
 pub const PLAY_SEEK: Selector<f64> = Selector::new("app.play-seek");
 

--- a/psst-gui/src/cmd.rs
+++ b/psst-gui/src/cmd.rs
@@ -4,7 +4,7 @@ use druid::{Selector, WidgetId};
 use psst_core::{item_id::ItemId, player::item::PlaybackItem};
 
 use crate::{
-    data::{Nav, PlaybackPayload, PlaylistTracks, QueueBehavior, QueueEntry},
+    data::{Nav, PlaybackPayload, QueueBehavior, QueueEntry},
     ui::find::Find,
 };
 

--- a/psst-gui/src/controller/playback.rs
+++ b/psst-gui/src/controller/playback.rs
@@ -294,6 +294,12 @@ impl PlaybackController {
         self.send(PlayerEvent::Command(PlayerCommand::SetVolume { volume }));
     }
 
+    fn add_to_queue(&mut self, item: &PlaybackItem) {
+        self.send(PlayerEvent::Command(PlayerCommand::AddToQueue {
+                item: item.clone(),
+            }));
+    }
+
     fn set_queue_behavior(&mut self, behavior: QueueBehavior) {
         self.send(PlayerEvent::Command(PlayerCommand::SetQueueBehavior {
             behavior: match behavior {
@@ -310,7 +316,7 @@ impl<W> Controller<AppState, W> for PlaybackController
 where
     W: Widget<AppState>,
 {
-    fn event(
+fn event(
         &mut self,
         child: &mut W,
         ctx: &mut EventCtx,
@@ -404,6 +410,12 @@ where
             }
             Event::Command(cmd) if cmd.is(cmd::PLAY_STOP) => {
                 self.stop();
+                ctx.set_handled();
+            }
+            Event::Command(cmd) if cmd.is(cmd::ADD_TO_QUEUE) => {
+                log::info!("adding to queue");
+                let item = cmd.get_unchecked(cmd::ADD_TO_QUEUE);
+                self.add_to_queue(&item.to_owned());
                 ctx.set_handled();
             }
             Event::Command(cmd) if cmd.is(cmd::PLAY_QUEUE_BEHAVIOR) => {

--- a/psst-gui/src/controller/playback.rs
+++ b/psst-gui/src/controller/playback.rs
@@ -348,12 +348,7 @@ fn event(
                     data.start_playback(queued.item, queued.origin, progress.to_owned());
                     self.update_media_control_playback(&data.playback);
                     self.update_media_control_metadata(&data.playback);
-                } else if let Some(queued) = data.queued_entry(*item) {
-                    data.start_playback(queued.item, queued.origin, progress.to_owned());
-                    self.update_media_control_playback(&data.playback);
-                    self.update_media_control_metadata(&data.playback);
                 }
-                
                 else {
                     log::warn!("played item not found in playback queue");
                 }
@@ -421,11 +416,9 @@ fn event(
             Event::Command(cmd) if cmd.is(cmd::ADD_TO_QUEUE) => {
                 log::info!("adding to queue");
                 let (entry, item) = cmd.get_unchecked(cmd::ADD_TO_QUEUE);
+
                 self.add_to_queue(&item.to_owned());
-                data.playback.added_queue.push_back(QueueEntry {
-                    item: entry.item.to_owned(),
-                    origin: entry.origin.to_owned(),
-                });
+                data.add_queued_entry(entry.clone());
                 ctx.set_handled();
             }
             Event::Command(cmd) if cmd.is(cmd::PLAY_QUEUE_BEHAVIOR) => {

--- a/psst-gui/src/controller/playback.rs
+++ b/psst-gui/src/controller/playback.rs
@@ -348,7 +348,13 @@ fn event(
                     data.start_playback(queued.item, queued.origin, progress.to_owned());
                     self.update_media_control_playback(&data.playback);
                     self.update_media_control_metadata(&data.playback);
-                } else {
+                } else if let Some(queued) = data.queued_entry(*item) {
+                    data.start_playback(queued.item, queued.origin, progress.to_owned());
+                    self.update_media_control_playback(&data.playback);
+                    self.update_media_control_metadata(&data.playback);
+                }
+                
+                else {
                     log::warn!("played item not found in playback queue");
                 }
                 ctx.set_handled();
@@ -414,8 +420,12 @@ fn event(
             }
             Event::Command(cmd) if cmd.is(cmd::ADD_TO_QUEUE) => {
                 log::info!("adding to queue");
-                let item = cmd.get_unchecked(cmd::ADD_TO_QUEUE);
+                let (entry, item) = cmd.get_unchecked(cmd::ADD_TO_QUEUE);
                 self.add_to_queue(&item.to_owned());
+                data.playback.added_queue.push_back(QueueEntry {
+                    item: entry.item.to_owned(),
+                    origin: entry.origin.to_owned(),
+                });
                 ctx.set_handled();
             }
             Event::Command(cmd) if cmd.is(cmd::PLAY_QUEUE_BEHAVIOR) => {

--- a/psst-gui/src/controller/playback.rs
+++ b/psst-gui/src/controller/playback.rs
@@ -296,8 +296,8 @@ impl PlaybackController {
 
     fn add_to_queue(&mut self, item: &PlaybackItem) {
         self.send(PlayerEvent::Command(PlayerCommand::AddToQueue {
-                item: *item,
-            }));
+            item: *item,
+        }));
     }
 
     fn set_queue_behavior(&mut self, behavior: QueueBehavior) {
@@ -316,7 +316,7 @@ impl<W> Controller<AppState, W> for PlaybackController
 where
     W: Widget<AppState>,
 {
-fn event(
+    fn event(
         &mut self,
         child: &mut W,
         ctx: &mut EventCtx,
@@ -348,8 +348,7 @@ fn event(
                     data.start_playback(queued.item, queued.origin, progress.to_owned());
                     self.update_media_control_playback(&data.playback);
                     self.update_media_control_metadata(&data.playback);
-                }
-                else {
+                } else {
                     log::warn!("played item not found in playback queue");
                 }
                 ctx.set_handled();
@@ -417,7 +416,7 @@ fn event(
                 log::info!("adding to queue");
                 let (entry, item) = cmd.get_unchecked(cmd::ADD_TO_QUEUE);
 
-                self.add_to_queue(&item.to_owned());
+                self.add_to_queue(item);
                 data.add_queued_entry(entry.clone());
                 ctx.set_handled();
             }

--- a/psst-gui/src/controller/playback.rs
+++ b/psst-gui/src/controller/playback.rs
@@ -296,7 +296,7 @@ impl PlaybackController {
 
     fn add_to_queue(&mut self, item: &PlaybackItem) {
         self.send(PlayerEvent::Command(PlayerCommand::AddToQueue {
-                item: item.clone(),
+                item: *item,
             }));
     }
 

--- a/psst-gui/src/data/mod.rs
+++ b/psst-gui/src/data/mod.rs
@@ -101,6 +101,7 @@ impl AppState {
             now_playing: None,
             queue_behavior: config.queue_behavior,
             queue: Vector::new(),
+            added_queue: Vector::new(),
             volume: config.volume,
         };
         Self {
@@ -180,6 +181,14 @@ impl AppState {
 
 impl AppState {
     pub fn queued_entry(&self, item_id: ItemId) -> Option<QueueEntry> {
+        self.playback
+            .queue
+            .iter()
+            .find(|queued| queued.item.id() == item_id)
+            .cloned()
+    }
+
+    pub fn added_queued_entry(&self, item_id: ItemId) -> Option<QueueEntry> {
         self.playback
             .queue
             .iter()

--- a/psst-gui/src/data/mod.rs
+++ b/psst-gui/src/data/mod.rs
@@ -181,19 +181,19 @@ impl AppState {
 
 impl AppState {
     pub fn queued_entry(&self, item_id: ItemId) -> Option<QueueEntry> {
-        self.playback
-            .queue
-            .iter()
-            .find(|queued| queued.item.id() == item_id)
-            .cloned()
+        if let Some(queued) = self.playback.queue.iter().find(|queued| queued.item.id() == item_id).cloned() {
+            return Some(queued);
+        } else if let Some(queued) = self.playback.added_queue.iter().find(|queued| queued.item.id() == item_id).cloned() {
+            return Some(queued);
+        } else {
+            None
+        }
     }
 
-    pub fn added_queued_entry(&self, item_id: ItemId) -> Option<QueueEntry> {
-        self.playback
-            .queue
-            .iter()
-            .find(|queued| queued.item.id() == item_id)
-            .cloned()
+    pub fn add_queued_entry(&mut self, queue_entry: QueueEntry) {
+        // it still gets updated and wiped when playlsit changes
+        self.playback.added_queue.push_back(queue_entry);
+
     }
 
     pub fn loading_playback(&mut self, item: Playable, origin: PlaybackOrigin) {

--- a/psst-gui/src/data/mod.rs
+++ b/psst-gui/src/data/mod.rs
@@ -182,9 +182,20 @@ impl AppState {
 
 impl AppState {
     pub fn queued_entry(&self, item_id: ItemId) -> Option<QueueEntry> {
-        if let Some(queued) = self.playback.queue.iter().find(|queued| queued.item.id() == item_id).cloned() {
+        if let Some(queued) = self
+            .playback
+            .queue
+            .iter()
+            .find(|queued| queued.item.id() == item_id)
+            .cloned()
+        {
             Some(queued)
-        } else if let Some(queued) = self.added_queue.iter().find(|queued| queued.item.id() == item_id).cloned() {
+        } else if let Some(queued) = self
+            .added_queue
+            .iter()
+            .find(|queued| queued.item.id() == item_id)
+            .cloned()
+        {
             return Some(queued);
         } else {
             None
@@ -194,7 +205,6 @@ impl AppState {
     pub fn add_queued_entry(&mut self, queue_entry: QueueEntry) {
         // it still gets updated and wiped when playlsit changes
         self.added_queue.push_back(queue_entry);
-
     }
 
     pub fn loading_playback(&mut self, item: Playable, origin: PlaybackOrigin) {

--- a/psst-gui/src/data/mod.rs
+++ b/psst-gui/src/data/mod.rs
@@ -80,6 +80,7 @@ pub struct AppState {
     pub personalized: Personalized,
     pub alerts: Vector<Alert>,
     pub finder: Finder,
+    pub added_queue: Vector<QueueEntry>,
 }
 
 impl AppState {
@@ -101,7 +102,6 @@ impl AppState {
             now_playing: None,
             queue_behavior: config.queue_behavior,
             queue: Vector::new(),
-            added_queue: Vector::new(),
             volume: config.volume,
         };
         Self {
@@ -119,6 +119,7 @@ impl AppState {
                 cache_size: Promise::Empty,
             },
             playback,
+            added_queue: Vector::new(),
             search: Search {
                 input: "".into(),
                 results: Promise::Empty,
@@ -183,7 +184,7 @@ impl AppState {
     pub fn queued_entry(&self, item_id: ItemId) -> Option<QueueEntry> {
         if let Some(queued) = self.playback.queue.iter().find(|queued| queued.item.id() == item_id).cloned() {
             return Some(queued);
-        } else if let Some(queued) = self.playback.added_queue.iter().find(|queued| queued.item.id() == item_id).cloned() {
+        } else if let Some(queued) = self.added_queue.iter().find(|queued| queued.item.id() == item_id).cloned() {
             return Some(queued);
         } else {
             None
@@ -192,7 +193,7 @@ impl AppState {
 
     pub fn add_queued_entry(&mut self, queue_entry: QueueEntry) {
         // it still gets updated and wiped when playlsit changes
-        self.playback.added_queue.push_back(queue_entry);
+        self.added_queue.push_back(queue_entry);
 
     }
 

--- a/psst-gui/src/data/mod.rs
+++ b/psst-gui/src/data/mod.rs
@@ -203,7 +203,6 @@ impl AppState {
     }
 
     pub fn add_queued_entry(&mut self, queue_entry: QueueEntry) {
-        // it still gets updated and wiped when playlsit changes
         self.added_queue.push_back(queue_entry);
     }
 

--- a/psst-gui/src/data/mod.rs
+++ b/psst-gui/src/data/mod.rs
@@ -183,7 +183,7 @@ impl AppState {
 impl AppState {
     pub fn queued_entry(&self, item_id: ItemId) -> Option<QueueEntry> {
         if let Some(queued) = self.playback.queue.iter().find(|queued| queued.item.id() == item_id).cloned() {
-            return Some(queued);
+            Some(queued)
         } else if let Some(queued) = self.added_queue.iter().find(|queued| queued.item.id() == item_id).cloned() {
             return Some(queued);
         } else {

--- a/psst-gui/src/data/playback.rs
+++ b/psst-gui/src/data/playback.rs
@@ -16,7 +16,6 @@ pub struct Playback {
     pub now_playing: Option<NowPlaying>,
     pub queue_behavior: QueueBehavior,
     pub queue: Vector<QueueEntry>,
-    pub added_queue: Vector<QueueEntry>,
     pub volume: f64,
 }
 

--- a/psst-gui/src/data/playback.rs
+++ b/psst-gui/src/data/playback.rs
@@ -16,6 +16,7 @@ pub struct Playback {
     pub now_playing: Option<NowPlaying>,
     pub queue_behavior: QueueBehavior,
     pub queue: Vector<QueueEntry>,
+    pub added_queue: Vector<QueueEntry>,
     pub volume: f64,
 }
 

--- a/psst-gui/src/ui/track.rs
+++ b/psst-gui/src/ui/track.rs
@@ -9,8 +9,7 @@ use psst_core::{audio::normalize::NormalizationLevel, item_id::{ItemId, ItemIdTy
 use crate::{
     cmd,
     data::{
-        AppState, Library, Nav, PlaybackOrigin, PlaylistAddTrack, PlaylistRemoveTrack,
-        RecommendationsRequest, Track,
+        self, AppState, Library, Nav, PlaybackOrigin, PlaylistAddTrack, PlaylistRemoveTrack, QueueEntry, RecommendationsRequest, Track
     },
     ui::playlist,
     widget::{icons, Empty, MyWidgetExt, RemoteImage},
@@ -329,10 +328,10 @@ pub fn track_menu(
             LocalizedString::new("menu-item-add-to-queue").with_placeholder("Add Track To Queue"),
         )
         //PlayerCommand
-        .command(cmd::ADD_TO_QUEUE.with(PlaybackItem{
+        .command(cmd::ADD_TO_QUEUE.with((QueueEntry {item: crate::ui::Playable::Track(track.clone()), origin: origin.clone()}, PlaybackItem{
             item_id: ItemId::from_base62(&String::from(track.id), ItemIdType::Track).unwrap(),
             norm_level: NormalizationLevel::Track,
-        })),
+        }))),
     );
 
     let mut playlist_menu = Menu::new(

--- a/psst-gui/src/ui/track.rs
+++ b/psst-gui/src/ui/track.rs
@@ -9,7 +9,7 @@ use psst_core::{audio::normalize::NormalizationLevel, item_id::{ItemId, ItemIdTy
 use crate::{
     cmd,
     data::{
-        self, AppState, Library, Nav, PlaybackOrigin, PlaylistAddTrack, PlaylistRemoveTrack, QueueEntry, RecommendationsRequest, Track
+        AppState, Library, Nav, PlaybackOrigin, PlaylistAddTrack, PlaylistRemoveTrack, QueueEntry, RecommendationsRequest, Track
     },
     ui::playlist,
     widget::{icons, Empty, MyWidgetExt, RemoteImage},

--- a/psst-gui/src/ui/track.rs
+++ b/psst-gui/src/ui/track.rs
@@ -4,12 +4,17 @@ use druid::{
     widget::{CrossAxisAlignment, Either, Flex, Label, ViewSwitcher},
     LensExt, LocalizedString, Menu, MenuItem, Size, TextAlignment, Widget, WidgetExt,
 };
-use psst_core::{audio::normalize::NormalizationLevel, item_id::{ItemId, ItemIdType}, player::item::PlaybackItem};
+use psst_core::{
+    audio::normalize::NormalizationLevel,
+    item_id::{ItemId, ItemIdType},
+    player::item::PlaybackItem,
+};
 
 use crate::{
     cmd,
     data::{
-        AppState, Library, Nav, PlaybackOrigin, PlaylistAddTrack, PlaylistRemoveTrack, QueueEntry, RecommendationsRequest, Track
+        AppState, Library, Nav, PlaybackOrigin, PlaylistAddTrack, PlaylistRemoveTrack, QueueEntry,
+        RecommendationsRequest, Track,
     },
     ui::playlist,
     widget::{icons, Empty, MyWidgetExt, RemoteImage},
@@ -328,10 +333,16 @@ pub fn track_menu(
             LocalizedString::new("menu-item-add-to-queue").with_placeholder("Add Track To Queue"),
         )
         //PlayerCommand
-        .command(cmd::ADD_TO_QUEUE.with((QueueEntry {item: crate::ui::Playable::Track(track.clone()), origin: origin.clone()}, PlaybackItem{
-            item_id: ItemId::from_base62(&String::from(track.id), ItemIdType::Track).unwrap(),
-            norm_level: NormalizationLevel::Track,
-        }))),
+        .command(cmd::ADD_TO_QUEUE.with((
+            QueueEntry {
+                item: crate::ui::Playable::Track(track.clone()),
+                origin: origin.clone(),
+            },
+            PlaybackItem {
+                item_id: ItemId::from_base62(&String::from(track.id), ItemIdType::Track).unwrap(),
+                norm_level: NormalizationLevel::Track,
+            },
+        ))),
     );
 
     let mut playlist_menu = Menu::new(

--- a/psst-gui/src/ui/track.rs
+++ b/psst-gui/src/ui/track.rs
@@ -4,6 +4,7 @@ use druid::{
     widget::{CrossAxisAlignment, Either, Flex, Label, ViewSwitcher},
     LensExt, LocalizedString, Menu, MenuItem, Size, TextAlignment, Widget, WidgetExt,
 };
+use psst_core::{audio::normalize::NormalizationLevel, item_id::{ItemId, ItemIdType}, player::item::PlaybackItem};
 
 use crate::{
     cmd,
@@ -322,6 +323,17 @@ pub fn track_menu(
             );
         }
     }
+
+    menu = menu.entry(
+        MenuItem::new(
+            LocalizedString::new("menu-item-add-to-queue").with_placeholder("Add Track To Queue"),
+        )
+        //PlayerCommand
+        .command(cmd::ADD_TO_QUEUE.with(PlaybackItem{
+            item_id: ItemId::from_base62(&String::from(track.id), ItemIdType::Track).unwrap(),
+            norm_level: NormalizationLevel::Track,
+        })),
+    );
 
     let mut playlist_menu = Menu::new(
         LocalizedString::new("menu-item-add-to-playlist").with_placeholder("Add to Playlist"),


### PR DESCRIPTION
This adds the ability to right-click on a song and add it to play next in the queue. Please do leave me feedback and critiques as this is my first time programming in rust!

Solves #431 !