### PR TITLE
Fix macOS preferences window contols and icon from side-panel

### DIFF
--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -114,7 +114,6 @@ fn root_widget() -> impl Widget<AppState> {
 
     let playlists = Flex::column()
         .must_fill_main_axis(true)
-        .with_child(sidebar_logo_widget())
         .with_child(sidebar_menu_widget())
         .with_default_spacer()
         .with_flex_child(playlists, 1.0)
@@ -267,15 +266,6 @@ fn route_widget() -> impl Widget<AppState> {
         },
     )
     .expand()
-}
-
-fn sidebar_logo_widget() -> impl Widget<AppState> {
-    icons::LOGO
-        .scale((29.0, 32.0))
-        .with_color(theme::GREY_500)
-        .padding((0.0, theme::grid(2.0), 0.0, theme::grid(1.0)))
-        .center()
-        .lens(Unit)
 }
 
 fn sidebar_menu_widget() -> impl Widget<AppState> {

--- a/psst-gui/src/ui/preferences.rs
+++ b/psst-gui/src/ui/preferences.rs
@@ -7,7 +7,7 @@ use druid::{
         Button, Controller, CrossAxisAlignment, Flex, Label, LineBreaking, MainAxisAlignment,
         RadioGroup, SizedBox, Slider, TextBox, ViewSwitcher,
     },
-    Color, Data, Env, Event, EventCtx, LensExt, LifeCycle, LifeCycleCtx, Selector, Widget,
+    Color, Data, Env, Event, EventCtx, Insets, LensExt, LifeCycle, LifeCycleCtx, Selector, Widget,
     WidgetExt,
 };
 use psst_core::connection::Credentials;
@@ -95,6 +95,12 @@ pub fn preferences_widget() -> impl Widget<AppState> {
         .scroll()
         .vertical()
         .content_must_fill(true)
+        .padding(if cfg!(target_os = "macos") {
+            // Accommodate the window controls on Mac.
+            Insets::new(0.0, 24.0, 0.0, 0.0)
+        } else {
+            Insets::ZERO
+        })
 }
 
 fn tabs_widget() -> impl Widget<AppState> {


### PR DESCRIPTION
This removes the old icon from the side panel as it was taking up a lot of space. It also fixes the window controls that were being overlapped on macOS.

Before:
<img width="185" alt="image" src="https://github.com/jpochyla/psst/assets/54308792/ebeb01f8-d32b-4e31-b3cc-c830d9d11532">

After:
<img width="184" alt="image" src="https://github.com/jpochyla/psst/assets/54308792/22f01a1f-36bd-4cfe-9d65-4868bf9db654">

<img width="305" alt="image" src="https://github.com/jpochyla/psst/assets/54308792/c1b8467d-2367-48fc-b9a6-3777641f65d4">

