### PR TITLE
Fix macOS universal build & support macOS >= 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,23 +51,15 @@ jobs:
         if: runner.os != 'macOS'
         run: cargo build --release
 
-      - name: Build for macOS (x86_64 and aarch64)
+      - name: Build for macOS (Universal Binary)
         if: runner.os == 'macOS'
         run: |
           rustup target add x86_64-apple-darwin aarch64-apple-darwin
           cargo build --release --target x86_64-apple-darwin
           cargo build --release --target aarch64-apple-darwin
-
-      - name: Create Universal Binary
-        if: runner.os == 'macOS'
-        run: |
-          lipo -create -output target/release/psst-gui-universal \
+          lipo -create -output target/release/psst-gui \
             target/x86_64-apple-darwin/release/psst-gui \
             target/aarch64-apple-darwin/release/psst-gui
-          if [ ! -f target/release/psst-gui-universal ]; then
-            echo "Failed to create universal binary"
-            exit 1
-          fi
 
       - name: Bundle macOS Release
         if: runner.os == 'macOS'
@@ -75,7 +67,7 @@ jobs:
           cargo install cargo-bundle
           cargo bundle --release
           mkdir -p target/release/bundle/osx/Psst.app/Contents/MacOS
-          cp ../target/release/psst-gui-universal target/release/bundle/osx/Psst.app/Contents/MacOS/psst-gui
+          cp target/release/psst-gui target/release/bundle/osx/Psst.app/Contents/MacOS/psst-gui
         working-directory: psst-gui
 
       - name: Create macOS Disk Image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,9 +66,8 @@ jobs:
         run: |
           cargo install cargo-bundle
           cargo bundle --release
-          mkdir -p target/release/bundle/osx/Psst.app/Contents/MacOS
-          cp target/release/psst-gui target/release/bundle/osx/Psst.app/Contents/MacOS/psst-gui
-        working-directory: psst-gui
+          mkdir -p psst-gui/target/release/bundle/osx/Psst.app/Contents/MacOS
+          cp target/release/psst-gui psst-gui/target/release/bundle/osx/Psst.app/Contents/MacOS/psst-gui
 
       - name: Create macOS Disk Image
         if: runner.os == 'macOS'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,14 +67,19 @@ jobs:
           cargo install cargo-bundle
           cargo bundle --release
           mkdir -p target/release/bundle/osx/Psst.app/Contents/MacOS
-          cp ../target/release/psst-gui target/release/bundle/osx/Psst.app/Contents/MacOS/psst-gui
-        working-directory: psst-gui
+          cp target/release/psst-gui target/release/bundle/osx/Psst.app/Contents/MacOS/psst-gui
 
       - name: Create macOS Disk Image
         if: runner.os == 'macOS'
         run: |
-          hdiutil create Psst-uncompressed.dmg -volname "Psst" -srcfolder psst-gui/target/release/bundle/osx
-          hdiutil convert Psst-uncompressed.dmg -format UDZO -o Psst.dmg
+          hdiutil create -volname "Psst" -srcfolder target/release/bundle/osx -ov -format UDZO Psst.dmg
+
+      - name: Upload macOS Disk Image
+        uses: actions/upload-artifact@v4
+        if: runner.os == 'macOS'
+        with:
+          name: Psst.dmg
+          path: ./Psst.dmg
 
       - name: Make Linux Binary Executable
         if: runner.os == 'Linux'
@@ -86,13 +91,6 @@ jobs:
         with:
           name: psst-gui
           path: target/release/psst-gui
-
-      - name: Upload macOS Disk Image
-        uses: actions/upload-artifact@v4
-        if: runner.os == 'macOS'
-        with:
-          name: Psst.dmg
-          path: ./Psst.dmg
 
       - name: Upload Windows Executable
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,8 +66,9 @@ jobs:
         run: |
           cargo install cargo-bundle
           cargo bundle --release
-          mkdir -p psst-gui/target/release/bundle/osx/Psst.app/Contents/MacOS
-          cp target/release/psst-gui psst-gui/target/release/bundle/osx/Psst.app/Contents/MacOS/psst-gui
+          mkdir -p target/release/bundle/osx/Psst.app/Contents/MacOS
+          cp ../target/release/psst-gui target/release/bundle/osx/Psst.app/Contents/MacOS/psst-gui
+        working-directory: psst-gui
 
       - name: Create macOS Disk Image
         if: runner.os == 'macOS'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,16 +58,16 @@ jobs:
           cargo build --release --target x86_64-apple-darwin --target aarch64-apple-darwin
 
       - name: Cache cargo-bundle
+        if: runner.os == 'macOS'
         id: cache-cargo-bundle
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cargo/bin/cargo-bundle
           key: ${{ runner.os }}-cargo-bundle-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install cargo-bundle
-        if: steps.cache-cargo-bundle.outputs.cache-hit != 'true'
+        if: runner.os == 'macOS' && steps.cache-cargo-bundle.outputs.cache-hit != 'true'
         run: cargo install cargo-bundle
-        working-directory: psst-gui
 
       - name: Bundle macOS Release
         if: runner.os == 'macOS'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    env:
+      MACOSX_DEPLOYMENT_TARGET: 12.0
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,7 @@ jobs:
         continue-on-error: true
 
       - name: Build Release
+        if: runner.os != 'macOS'
         run: cargo build --release
 
       - name: Build for macOS (x86_64 and aarch64)
@@ -63,19 +64,24 @@ jobs:
           lipo -create -output target/release/psst-gui-universal \
             target/x86_64-apple-darwin/release/psst-gui \
             target/aarch64-apple-darwin/release/psst-gui
+          if [ ! -f target/release/psst-gui-universal ]; then
+            echo "Failed to create universal binary"
+            exit 1
+          fi
 
       - name: Bundle macOS Release
         if: runner.os == 'macOS'
         run: |
           cargo install cargo-bundle
           cargo bundle --release
-          cp target/release/psst-gui-universal target/release/bundle/osx/Psst.app/Contents/MacOS/psst-gui
+          mkdir -p target/release/bundle/osx/Psst.app/Contents/MacOS
+          cp ../target/release/psst-gui-universal target/release/bundle/osx/Psst.app/Contents/MacOS/psst-gui
         working-directory: psst-gui
 
       - name: Create macOS Disk Image
         if: runner.os == 'macOS'
         run: |
-          hdiutil create Psst-uncompressed.dmg -volname "Psst" -srcfolder target/release/bundle/osx
+          hdiutil create Psst-uncompressed.dmg -volname "Psst" -srcfolder psst-gui/target/release/bundle/osx
           hdiutil convert Psst-uncompressed.dmg -format UDZO -o Psst.dmg
 
       - name: Make Linux Binary Executable

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Cache
         uses: Swatinem/rust-cache@v2
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Cache
         uses: Swatinem/rust-cache@v2
@@ -46,6 +46,9 @@ jobs:
       - name: Run Tests
         run: cargo test
         continue-on-error: true
+
+      - name: Build Release
+        run: cargo build --release
 
       - name: Build for macOS (x86_64 and aarch64)
         if: runner.os == 'macOS'
@@ -80,21 +83,21 @@ jobs:
         run: chmod +x target/release/psst-gui
 
       - name: Upload Linux Binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: runner.os == 'Linux'
         with:
           name: psst-gui
           path: target/release/psst-gui
 
       - name: Upload macOS Disk Image
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: runner.os == 'macOS'
         with:
           name: Psst.dmg
           path: ./Psst.dmg
 
       - name: Upload Windows Executable
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: runner.os == 'Windows'
         with:
           name: Psst.exe
@@ -105,10 +108,10 @@ jobs:
     needs: build
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download Linux Binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: psst-gui
           path: ${{runner.workspace}}
@@ -147,7 +150,7 @@ jobs:
         run: cat ${{runner.workspace}}/pkg/DEBIAN/control && dpkg-deb -b ${{runner.workspace}}/pkg/ psst_$(git rev-list --count HEAD)_amd64.deb
 
       - name: Upload Debian Package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: psst-deb
           path: "*.deb"
@@ -158,10 +161,10 @@ jobs:
     needs: deb
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download Debian Package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: psst-deb
           path: ${{runner.workspace}}
@@ -194,7 +197,7 @@ jobs:
           ${{env.app_path}} ${{env.recipe_path}}
 
       - name: Upload AppImage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: psst-appimage
           path: ${{runner.workspace}}/out/*.AppImage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,34 +47,27 @@ jobs:
         run: cargo test
         continue-on-error: true
 
-      - name: Build Release
-        run: cargo build --release
-
-      - name: Build x86_64 for MacOS
+      - name: Build for macOS (x86_64 and aarch64)
         if: runner.os == 'macOS'
         run: |
-          rustup target add x86_64-apple-darwin
+          rustup target add x86_64-apple-darwin aarch64-apple-darwin
           cargo build --release --target x86_64-apple-darwin
+          cargo build --release --target aarch64-apple-darwin
 
-      - name: Build aarch64 for MacOS
+      - name: Create Universal Binary
         if: runner.os == 'macOS'
         run: |
-          rustup target add aarch64-apple-darwin
-          cargo build --release --target aarch64-apple-darwin
+          lipo -create -output target/release/psst-gui-universal \
+            target/x86_64-apple-darwin/release/psst-gui \
+            target/aarch64-apple-darwin/release/psst-gui
 
       - name: Bundle macOS Release
         if: runner.os == 'macOS'
         run: |
           cargo install cargo-bundle
           cargo bundle --release
+          cp target/release/psst-gui-universal target/release/bundle/osx/Psst.app/Contents/MacOS/psst-gui
         working-directory: psst-gui
-
-      - name: Create macOS universal binary
-        if: runner.os == 'macOS'
-        run: |
-          lipo -create -output target/release/bundle/osx/Psst.app/Contents/MacOS/psst-gui \
-            target/x86_64-apple-darwin/release/psst-gui \
-            target/aarch64-apple-darwin/release/psst-gui
 
       - name: Create macOS Disk Image
         if: runner.os == 'macOS'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,28 +51,39 @@ jobs:
         if: runner.os != 'macOS'
         run: cargo build --release
 
-      - name: Build for macOS (Universal Binary)
+      - name: Build x86_64 and aarch64 for macOS
         if: runner.os == 'macOS'
         run: |
           rustup target add x86_64-apple-darwin aarch64-apple-darwin
-          cargo build --release --target x86_64-apple-darwin
-          cargo build --release --target aarch64-apple-darwin
-          lipo -create -output target/release/psst-gui \
-            target/x86_64-apple-darwin/release/psst-gui \
-            target/aarch64-apple-darwin/release/psst-gui
+          cargo build --release --target x86_64-apple-darwin --target aarch64-apple-darwin
+
+      - name: Cache cargo-bundle
+        id: cache-cargo-bundle
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/bin/cargo-bundle
+          key: ${{ runner.os }}-cargo-bundle-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install cargo-bundle
+        if: steps.cache-cargo-bundle.outputs.cache-hit != 'true'
+        run: cargo install cargo-bundle
+        working-directory: psst-gui
 
       - name: Bundle macOS Release
         if: runner.os == 'macOS'
+        run: cargo bundle --release
+        working-directory: psst-gui
+
+      - name: Create macOS universal binary
+        if: runner.os == 'macOS'
         run: |
-          cargo install cargo-bundle
-          cargo bundle --release
-          mkdir -p target/release/bundle/osx/Psst.app/Contents/MacOS
-          cp target/release/psst-gui target/release/bundle/osx/Psst.app/Contents/MacOS/psst-gui
+          lipo -create -output target/release/bundle/osx/Psst.app/Contents/MacOS/psst-gui \
+            target/x86_64-apple-darwin/release/psst-gui \
+            target/aarch64-apple-darwin/release/psst-gui
 
       - name: Create macOS Disk Image
         if: runner.os == 'macOS'
-        run: |
-          hdiutil create -volname "Psst" -srcfolder target/release/bundle/osx -ov -format UDZO Psst.dmg
+        run: hdiutil create -volname "Psst" -srcfolder target/release/bundle/osx -ov -format UDZO Psst.dmg
 
       - name: Upload macOS Disk Image
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:
-      MACOSX_DEPLOYMENT_TARGET: 12.0
+      MACOSX_DEPLOYMENT_TARGET: 11.0
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/psst-gui/src/data/album.rs
+++ b/psst-gui/src/data/album.rs
@@ -51,7 +51,7 @@ impl Album {
     pub fn release_year_int(&self) -> usize {
         self.release_year().parse::<usize>().unwrap_or_else(|err| {
             log::error!("Error parsing release year for {}: {}", self.name, err);
-            std::usize::MAX
+            usize::MAX
         })
     }
 

--- a/psst-gui/src/webapi/client.rs
+++ b/psst-gui/src/webapi/client.rs
@@ -263,8 +263,8 @@ impl WebApi {
             appears_on: Vector::new(),
         };
 
-        let mut last_album_release_year = std::usize::MAX;
-        let mut last_single_release_year = std::usize::MAX;
+        let mut last_album_release_year = usize::MAX;
+        let mut last_single_release_year = usize::MAX;
 
         for album in result {
             match album.album_type {


### PR DESCRIPTION
This fixes an issue with our universal builds, it also:
- adds the `MACOSX_DEPLOYMENT_TARGET` so we can support older versions than what the macOS runner is set to
- Lints a few depreciated `usize` imports
- Bumps the version of the actions to use Node 20 so we don't get depreciation warnings