### PR TITLE
Save config on exit, not interaction

### DIFF
--- a/psst-gui/src/cmd.rs
+++ b/psst-gui/src/cmd.rs
@@ -9,36 +9,31 @@ use crate::{
 };
 
 // Widget IDs
-
 pub const WIDGET_SEARCH_INPUT: WidgetId = WidgetId::reserved(1);
 
 // Common
-
 pub const SHOW_MAIN: Selector = Selector::new("app.show-main");
 pub const SHOW_ACCOUNT_SETUP: Selector = Selector::new("app.show-initial");
 pub const CLOSE_ALL_WINDOWS: Selector = Selector::new("app.close-all-windows");
+pub const QUIT_APP_WITH_SAVE: Selector = Selector::new("app.quit-with-save");
 pub const SET_FOCUS: Selector = Selector::new("app.set-focus");
 pub const COPY: Selector<String> = Selector::new("app.copy-to-clipboard");
 
 // Find
-
 pub const TOGGLE_FINDER: Selector = Selector::new("app.show-finder");
 pub const FIND_IN_PLAYLIST: Selector<Find> = Selector::new("find-in-playlist");
 pub const FIND_IN_SAVED_TRACKS: Selector<Find> = Selector::new("find-in-saved-tracks");
 
 // Session
-
 pub const SESSION_CONNECT: Selector = Selector::new("app.session-connect");
 pub const LOG_OUT: Selector = Selector::new("app.log-out");
 
 // Navigation
-
 pub const NAVIGATE: Selector<Nav> = Selector::new("app.navigates");
 pub const NAVIGATE_BACK: Selector<usize> = Selector::new("app.navigate-back");
 pub const NAVIGATE_REFRESH: Selector = Selector::new("app.navigate-refresh");
 
 // Playback state
-
 pub const PLAYBACK_LOADING: Selector<ItemId> = Selector::new("app.playback-loading");
 pub const PLAYBACK_PLAYING: Selector<(ItemId, Duration)> = Selector::new("app.playback-playing");
 pub const PLAYBACK_PROGRESS: Selector<Duration> = Selector::new("app.playback-progress");
@@ -48,7 +43,6 @@ pub const PLAYBACK_BLOCKED: Selector = Selector::new("app.playback-blocked");
 pub const PLAYBACK_STOPPED: Selector = Selector::new("app.playback-stopped");
 
 // Playback control
-
 pub const PLAY: Selector<usize> = Selector::new("app.play-index");
 pub const PLAY_TRACKS: Selector<PlaybackPayload> = Selector::new("app.play-tracks");
 pub const PLAY_PREVIOUS: Selector = Selector::new("app.play-previous");
@@ -67,5 +61,5 @@ pub const SORT_BY_ARTIST: Selector = Selector::new("app.sort-by-artist");
 pub const SORT_BY_ALBUM: Selector = Selector::new("app.sort-by-album");
 pub const SORT_BY_DURATION: Selector = Selector::new("app.sort-by-duration");
 
-//Sort direction control
+// Sort direction control
 pub const TOGGLE_SORT_ORDER: Selector = Selector::new("app.toggle-sort-order");

--- a/psst-gui/src/controller/sort.rs
+++ b/psst-gui/src/controller/sort.rs
@@ -27,14 +27,12 @@ where
                     data.config.sort_order = SortOrder::Ascending;
                 }
 
-                data.config.save();
                 ctx.submit_command(cmd::NAVIGATE_REFRESH);
                 ctx.set_handled();
             }
             Event::Command(cmd) if cmd.is(cmd::SORT_BY_TITLE) => {
                 if data.config.sort_criteria != SortCriteria::Title {
                     data.config.sort_criteria = SortCriteria::Title;
-                    data.config.save();
                     ctx.submit_command(cmd::NAVIGATE_REFRESH);
                     ctx.set_handled();
                 }
@@ -42,7 +40,6 @@ where
             Event::Command(cmd) if cmd.is(cmd::SORT_BY_ALBUM) => {
                 if data.config.sort_criteria != SortCriteria::Album {
                     data.config.sort_criteria = SortCriteria::Album;
-                    data.config.save();
                     ctx.submit_command(cmd::NAVIGATE_REFRESH);
                     ctx.set_handled();
                 }
@@ -50,7 +47,6 @@ where
             Event::Command(cmd) if cmd.is(cmd::SORT_BY_DATE_ADDED) => {
                 if data.config.sort_criteria != SortCriteria::DateAdded {
                     data.config.sort_criteria = SortCriteria::DateAdded;
-                    data.config.save();
                     ctx.submit_command(cmd::NAVIGATE_REFRESH);
                     ctx.set_handled();
                 }
@@ -58,7 +54,6 @@ where
             Event::Command(cmd) if cmd.is(cmd::SORT_BY_ARTIST) => {
                 if data.config.sort_criteria != SortCriteria::Artist {
                     data.config.sort_criteria = SortCriteria::Artist;
-                    data.config.save();
                     ctx.submit_command(cmd::NAVIGATE_REFRESH);
                     ctx.set_handled();
                 }
@@ -66,7 +61,6 @@ where
             Event::Command(cmd) if cmd.is(cmd::SORT_BY_DURATION) => {
                 if data.config.sort_criteria != SortCriteria::Duration {
                     data.config.sort_criteria = SortCriteria::Duration;
-                    data.config.save();
                     ctx.submit_command(cmd::NAVIGATE_REFRESH);
                     ctx.set_handled();
                 }

--- a/psst-gui/src/data/mod.rs
+++ b/psst-gui/src/data/mod.rs
@@ -162,14 +162,12 @@ impl AppState {
             let previous: Nav = mem::replace(&mut self.nav, nav.to_owned());
             self.history.push_back(previous);
             self.config.last_route.replace(nav.to_owned());
-            self.config.save();
         }
     }
 
     pub fn navigate_back(&mut self) {
         if let Some(nav) = self.history.pop_back() {
             self.config.last_route.replace(nav.clone());
-            self.config.save();
             self.nav = nav;
         }
     }

--- a/psst-gui/src/data/playlist.rs
+++ b/psst-gui/src/data/playlist.rs
@@ -27,7 +27,7 @@ pub struct PlaylistRemoveTrack {
 pub struct Playlist {
     pub id: Arc<str>,
     pub name: Arc<str>,
-    #[serde(skip_serializing_if="Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub images: Option<Vector<Image>>,
     pub description: Arc<str>,
     #[serde(rename = "tracks")]
@@ -46,9 +46,9 @@ impl Playlist {
     }
 
     pub fn image(&self, width: f64, height: f64) -> Option<&Image> {
-        self.images.as_ref().and_then(|images| {
-            Image::at_least_of_size(images, width, height)
-        })
+        self.images
+            .as_ref()
+            .and_then(|images| Image::at_least_of_size(images, width, height))
     }
 
     pub fn url(&self) -> String {

--- a/psst-gui/src/delegate.rs
+++ b/psst-gui/src/delegate.rs
@@ -137,6 +137,13 @@ impl AppDelegate<AppState> for Delegate {
         } else if let Some(link) = cmd.get(RENAME_PLAYLIST_CONFIRM) {
             ctx.submit_command(RENAME_PLAYLIST.with(link.clone()));
             Handled::Yes
+        } else if cmd.is(cmd::QUIT_APP_WITH_SAVE) {
+            data.config.save();
+            ctx.submit_command(commands::QUIT_APP);
+            Handled::Yes
+        } else if cmd.is(commands::QUIT_APP) {
+            data.config.save();
+            Handled::No
         } else {
             Handled::No
         }

--- a/psst-gui/src/ui/menu.rs
+++ b/psst-gui/src/ui/menu.rs
@@ -26,7 +26,7 @@ fn mac_app_menu() -> Menu<AppState> {
             //  This is just overriding `platform_menus::mac::application::quit()`
             //  because l10n is a bit stupid now.
             MenuItem::new(LocalizedString::new("macos-menu-quit").with_placeholder("Quit Psst"))
-                .command(commands::QUIT_APP)
+                .command(cmd::QUIT_APP_WITH_SAVE)
                 .hotkey(SysMods::Cmd, "q"),
         )
         .entry(

--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -342,7 +342,6 @@ fn volume_slider() -> impl Widget<AppState> {
         )
         .on_command(SAVE_TO_CONFIG, |_, _, data| {
             data.config.volume = data.playback.volume;
-            data.config.save();
         })
 }
 


### PR DESCRIPTION
This changes the behavior of how we save the config to save only when Psst is completely closed. This reduces the unnecessary need to save the config anytime the state changes.

Ideally, we should be able to capture all instances of an application closing, except in the most extreme case, so that we can restore the state from its last configuration.

There appears to be a workaround for macOS to handle the Cmd+Q hotkey given that it doesn't seem at least on macOS that you can capture the QUIT_APP command. This will need to be tested on Windows and Linux.