### PR TITLE
Fix unavailable playlists erroring playlist load

### DIFF
--- a/psst-gui/src/data/mod.rs
+++ b/psst-gui/src/data/mod.rs
@@ -433,22 +433,16 @@ impl Library {
 
     pub fn increment_playlist_track_count(&mut self, link: &PlaylistLink) {
         if let Some(saved) = self.playlists.resolved_mut() {
-            for playlist in saved.iter_mut() {
-                if playlist.id == link.id {
-                    playlist.track_count += 1;
-                    break;
-                }
+            if let Some(playlist) = saved.iter_mut().find(|p| p.id == link.id) {
+                playlist.track_count = playlist.track_count.map(|count| count + 1);
             }
         }
     }
 
     pub fn decrement_playlist_track_count(&mut self, link: &PlaylistLink) {
         if let Some(saved) = self.playlists.resolved_mut() {
-            for playlist in saved.iter_mut() {
-                if playlist.id == link.id {
-                    playlist.track_count -= 1;
-                    break;
-                }
+            if let Some(playlist) = saved.iter_mut().find(|p| p.id == link.id) {
+                playlist.track_count = playlist.track_count.map(|count| count.saturating_sub(1));
             }
         }
     }

--- a/psst-gui/src/data/playlist.rs
+++ b/psst-gui/src/data/playlist.rs
@@ -32,7 +32,7 @@ pub struct Playlist {
     pub description: Arc<str>,
     #[serde(rename = "tracks")]
     #[serde(deserialize_with = "deserialize_track_count")]
-    pub track_count: usize,
+    pub track_count: Option<usize>,
     pub owner: PublicUser,
     pub collaborative: bool,
 }
@@ -78,13 +78,13 @@ pub struct PlaylistLink {
     pub name: Arc<str>,
 }
 
-fn deserialize_track_count<'de, D>(deserializer: D) -> Result<usize, D::Error>
+fn deserialize_track_count<'de, D>(deserializer: D) -> Result<Option<usize>, D::Error>
 where
     D: Deserializer<'de>,
 {
     #[derive(Deserialize)]
     struct PlaylistTracksRef {
-        total: usize,
+        total: Option<usize>,
     }
 
     Ok(PlaylistTracksRef::deserialize(deserializer)?.total)


### PR DESCRIPTION
We needed to make `track_count` nullable.