### PR TITLE
Cache album art

### DIFF
--- a/psst-gui/src/webapi/cache.rs
+++ b/psst-gui/src/webapi/cache.rs
@@ -39,7 +39,7 @@ impl WebApiCache {
         self.key("images", &format!("{:016x}", hash))
             .and_then(|path| std::fs::read(path).ok())
             .and_then(|bytes| image::load_from_memory(&bytes).ok())
-            .map(|dynamic_image| ImageBuf::from_dynamic_image(dynamic_image))
+            .map(ImageBuf::from_dynamic_image)
     }
 
     pub fn save_image_to_disk(&self, uri: &Arc<str>, data: &[u8]) {

--- a/psst-gui/src/webapi/client.rs
+++ b/psst-gui/src/webapi/client.rs
@@ -726,6 +726,15 @@ impl WebApi {
     }
 
     pub fn get_image(&self, uri: Arc<str>) -> Result<ImageBuf, Error> {
+        if let Some(cached_image) = self.cache.get_image(&uri) {
+            return Ok(cached_image);
+        }
+
+        if let Some(disk_cached_image) = self.cache.get_image_from_disk(&uri) {
+            self.cache.set_image(uri.clone(), disk_cached_image.clone());
+            return Ok(disk_cached_image);
+        }
+
         let response = self.agent.get(&uri).call()?;
         let format = match response.content_type() {
             "image/jpeg" => Some(ImageFormat::Jpeg),
@@ -734,6 +743,10 @@ impl WebApi {
         };
         let mut body = Vec::new();
         response.into_reader().read_to_end(&mut body)?;
+
+        // Save raw image data to disk cache
+        self.cache.save_image_to_disk(&uri, &body);
+
         let image = if let Some(format) = format {
             image::load_from_memory_with_format(&body, format)?
         } else {


### PR DESCRIPTION
Currently, this stores the album art work by hashed URI.

Ideally, we would be storing and retrieving the album art by the album ID. However, that would mean modifying the function in a way that I think would warrant its own PR. With that extension, we would only need to download album artwork for each album rather than album art for each track, which is happening now.

I think the increase in cache size is negligible here, given that each album cover as a small thumbnail is about 2-6kb and has a large thumbnail about ~40kb.

This will reduce the number of requests,  improve responsiveness and CPU likely.