### PR TITLE
Move to libssl3

### DIFF
--- a/.pkg/DEBIAN/control
+++ b/.pkg/DEBIAN/control
@@ -1,4 +1,5 @@
 Package: psst-gui
+Version: 0.1.0
 Architecture: amd64
 Maintainer: Jan Pochyla <jpochyla@gmail.com>
 Section: sound

--- a/.pkg/DEBIAN/control
+++ b/.pkg/DEBIAN/control
@@ -5,5 +5,5 @@ Section: sound
 Priority: optional
 Homepage: https://github.com/jpochyla/psst
 Package-Type: deb
-Depends: libssl, libgtk-3-0, libcairo2
+Depends: libssl3 | libssl1.1, libgtk-3-0, libcairo2
 Description: Fast and multi-platform Spotify client with native GUI

--- a/.pkg/DEBIAN/control
+++ b/.pkg/DEBIAN/control
@@ -5,5 +5,5 @@ Section: sound
 Priority: optional
 Homepage: https://github.com/jpochyla/psst
 Package-Type: deb
-Depends: libssl1.1, libgtk-3-0, libcairo2
+Depends: libssl, libgtk-3-0, libcairo2
 Description: Fast and multi-platform Spotify client with native GUI


### PR DESCRIPTION
Should resolve https://github.com/jpochyla/psst/issues/415

Need to see if debs are still installable on Ubuntu 20?