### PR TITLE
Refresh saved tracks in the background

### DIFF
--- a/psst-gui/src/ui/track.rs
+++ b/psst-gui/src/ui/track.rs
@@ -154,7 +154,8 @@ pub fn playable_widget(track: &Track, display: Display) -> impl Widget<PlayRow<A
                 if row.ctx.library.contains_track(track) {
                     ctx.submit_command(library::UNSAVE_TRACK.with(track.id))
                 } else {
-                    ctx.submit_command(library::SAVE_TRACK.with(track.clone()))
+                    ctx.submit_command(library::SAVE_TRACK.with(track.clone()));
+                    ctx.submit_command(library::LOAD_TRACKS);
                 }
             })
             .boxed(),


### PR DESCRIPTION
This solves issue #501 by simply refreshing the saved tracks in the background after the user has pressed the save button. 