### PR TITLE
Make volume slider one line

### DIFF
--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -132,7 +132,7 @@ fn root_widget() -> impl Widget<AppState> {
         .with_default_spacer()
         .with_child(user::user_widget())
         .center()
-        .fix_height(100.0)
+        .fix_height(88.0)
         .background(Border::Top.with_color(theme::GREY_500));
 
     let sidebar = Flex::column()

--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -335,7 +335,7 @@ fn volume_slider() -> impl Widget<AppState> {
                 .with_text_color(theme::PLACEHOLDER_COLOR)
                 .with_text_size(theme::TEXT_SIZE_SMALL),
         )
-        .padding((theme::grid(1.5), 0.0))
+        .padding((theme::grid(2.0), 0.0))
         .on_debounce(SAVE_DELAY, |ctx, _, _| ctx.submit_command(SAVE_TO_CONFIG))
         .lens(AppState::playback.then(Playback::volume))
         .on_scroll(
@@ -344,9 +344,6 @@ fn volume_slider() -> impl Widget<AppState> {
                 data.playback.volume = (data.playback.volume + scaled_delta).clamp(0.0, 1.0);
             },
         )
-        .on_command(SAVE_TO_CONFIG, |_, _, data| {
-            data.config.volume = data.playback.volume;
-        })
 }
 
 fn topbar_sort_widget() -> impl Widget<AppState> {

--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -316,14 +316,8 @@ fn volume_slider() -> impl Widget<AppState> {
     const SAVE_DELAY: Duration = Duration::from_millis(100);
     const SAVE_TO_CONFIG: Selector = Selector::new("app.volume.save-to-config");
 
-    Flex::column()
-        .with_child(
-            Label::dynamic(|&volume: &f64, _| format!("Volume: {}%", (volume * 100.0).floor()))
-                .with_text_color(theme::PLACEHOLDER_COLOR)
-                .with_text_size(theme::TEXT_SIZE_SMALL),
-        )
-        .with_default_spacer()
-        .with_child(
+    Flex::row()
+        .with_flex_child(
             Slider::new()
                 .with_range(0.0, 1.0)
                 .expand_width()
@@ -333,6 +327,13 @@ fn volume_slider() -> impl Widget<AppState> {
                     env.set(theme::FOREGROUND_DARK, env.get(theme::GREY_400));
                 })
                 .with_cursor(Cursor::Pointer),
+            1.0,
+        )
+        .with_default_spacer()
+        .with_child(
+            Label::dynamic(|&volume: &f64, _| format!("{}%", (volume * 100.0).floor()))
+                .with_text_color(theme::PLACEHOLDER_COLOR)
+                .with_text_size(theme::TEXT_SIZE_SMALL),
         )
         .padding((theme::grid(1.5), 0.0))
         .on_debounce(SAVE_DELAY, |ctx, _, _| ctx.submit_command(SAVE_TO_CONFIG))

--- a/psst-gui/src/ui/user.rs
+++ b/psst-gui/src/ui/user.rs
@@ -48,14 +48,10 @@ pub fn user_widget() -> impl Widget<AppState> {
             Flex::column()
                 .with_child(is_connected)
                 .with_default_spacer()
-                .with_child(user_profile),
+                .with_child(user_profile)
+                .padding(theme::grid(1.0)),
         )
-        .with_flex_spacer(1.0)
         .with_child(preferences_widget(&icons::PREFERENCES))
-        .padding(theme::grid(1.0))
-        .background(theme::LINK_ACTIVE_COLOR)
-        .rounded(theme::BUTTON_BORDER_RADIUS)
-        .padding((theme::grid(1.0), theme::grid(0.5)))
 }
 
 fn preferences_widget<T: Data>(svg: &SvgIcon) -> impl Widget<T> {

--- a/psst-gui/src/ui/user.rs
+++ b/psst-gui/src/ui/user.rs
@@ -1,7 +1,7 @@
 use druid::{
     commands,
-    widget::{Either, Flex, Label},
-    Data, LensExt, Selector, Widget, WidgetExt,
+    widget::{Either, Flex, Label, Painter},
+    Data, Env, KeyOrValue, LensExt, RenderContext, Selector, Widget, WidgetExt,
 };
 
 use crate::{
@@ -47,10 +47,15 @@ pub fn user_widget() -> impl Widget<AppState> {
         .with_child(
             Flex::column()
                 .with_child(is_connected)
-                .with_child(user_profile)
-                .padding((theme::grid(2.0), theme::grid(1.5))),
+                .with_default_spacer()
+                .with_child(user_profile),
         )
+        .with_flex_spacer(1.0)
         .with_child(preferences_widget(&icons::PREFERENCES))
+        .padding(theme::grid(1.0))
+        .background(theme::LINK_ACTIVE_COLOR)
+        .rounded(theme::BUTTON_BORDER_RADIUS)
+        .padding((theme::grid(1.0), theme::grid(0.5)))
 }
 
 fn preferences_widget<T: Data>(svg: &SvgIcon) -> impl Widget<T> {

--- a/psst-gui/src/ui/user.rs
+++ b/psst-gui/src/ui/user.rs
@@ -1,7 +1,7 @@
 use druid::{
     commands,
-    widget::{Either, Flex, Label, Painter},
-    Data, Env, KeyOrValue, LensExt, RenderContext, Selector, Widget, WidgetExt,
+    widget::{Either, Flex, Label},
+    Data, LensExt, Selector, Widget, WidgetExt,
 };
 
 use crate::{


### PR DESCRIPTION
It never made any sense to me why the volume controls were on two separate lines. It only contributed to the height of that very minimal controls panel. I think this makes a lot more sense and we don't need the volume title given that this is intuitive.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/0c802ede-04f3-4b5a-8c3e-0cc803f005f8">