### PR TITLE
Truncate playable widget

### DIFF
--- a/psst-core/src/oauth.rs
+++ b/psst-core/src/oauth.rs
@@ -45,8 +45,7 @@ pub fn listen_for_callback_parameter(
             handle_callback_connection(&mut stream, &tx, parameter_name);
         } else {
             log::error!("Failed to accept connection on callback listener");
-            let _ = tx.send(Err(Error::IoError(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            let _ = tx.send(Err(Error::IoError(std::io::Error::other(
                 "Failed to accept connection",
             ))));
         }
@@ -97,8 +96,7 @@ fn handle_callback_connection(
         }
     } else {
         log::error!("Failed to read request line from callback.");
-        let _ = tx.send(Err(Error::IoError(std::io::Error::new(
-            std::io::ErrorKind::Other,
+        let _ = tx.send(Err(Error::IoError(std::io::Error::other(
             "Failed to read request line",
         ))));
     }

--- a/psst-gui/src/data/playback.rs
+++ b/psst-gui/src/data/playback.rs
@@ -25,7 +25,7 @@ pub struct QueueEntry {
     pub origin: PlaybackOrigin,
 }
 
-#[derive(Clone, Debug, Data, Matcher)]
+#[derive(Clone, Debug, Matcher)]
 pub enum Playable {
     Track(Arc<Track>),
     Episode(Arc<Episode>),
@@ -59,6 +59,16 @@ impl Playable {
             Playable::Track(track) => track.duration,
             Playable::Episode(episode) => episode.duration,
         }
+    }
+
+    pub fn same(&self, other: &Self) -> bool {
+        self.id() == other.id()
+    }
+}
+
+impl Data for Playable {
+    fn same(&self, other: &Self) -> bool {
+        self.same(other)
     }
 }
 

--- a/psst-gui/src/delegate.rs
+++ b/psst-gui/src/delegate.rs
@@ -4,7 +4,7 @@ use druid::{
     WindowDesc, WindowId,
 };
 use std::fs;
-use std::io::{BufReader, Read};
+use std::io::Read;
 use threadpool::ThreadPool;
 
 use crate::ui::playlist::{
@@ -208,11 +208,11 @@ impl AppDelegate<AppState> for Delegate {
                     match ureq::get(url)
                         .call()
                         .and_then(|response| {
-                            let mut reader = BufReader::new(response.into_reader());
-                            let mut buffer = Vec::new();
-                            reader
-                                .read_to_end(&mut buffer)
-                                .map(|_| buffer)
+                            response
+                                .into_body()
+                                .into_reader()
+                                .bytes()
+                                .collect::<Result<Vec<_>, _>>()
                                 .map_err(|e| e.into())
                         })
                         .and_then(|bytes| fs::write(&path, bytes).map_err(|e| e.into()))

--- a/psst-gui/src/delegate.rs
+++ b/psst-gui/src/delegate.rs
@@ -4,7 +4,7 @@ use druid::{
     WindowDesc, WindowId,
 };
 use std::fs;
-use std::io::Read;
+use std::io::{BufReader, Read};
 use threadpool::ThreadPool;
 
 use crate::ui::playlist::{
@@ -208,11 +208,11 @@ impl AppDelegate<AppState> for Delegate {
                     match ureq::get(url)
                         .call()
                         .and_then(|response| {
-                            response
-                                .into_body()
-                                .into_reader()
-                                .bytes()
-                                .collect::<Result<Vec<_>, _>>()
+                            let mut reader = BufReader::new(response.into_reader());
+                            let mut buffer = Vec::new();
+                            reader
+                                .read_to_end(&mut buffer)
+                                .map(|_| buffer)
                                 .map_err(|e| e.into())
                         })
                         .and_then(|bytes| fs::write(&path, bytes).map_err(|e| e.into()))

--- a/psst-gui/src/ui/playable.rs
+++ b/psst-gui/src/ui/playable.rs
@@ -81,15 +81,15 @@ pub fn is_playing_marker_widget() -> impl Widget<bool> {
     Painter::new(|ctx, is_playing, env| {
         const STYLE: StrokeStyle = StrokeStyle::new().dash_pattern(&[1.0, 2.0]);
 
-        let line = Line::new((0.0, 0.0), (ctx.size().width, 0.0));
+        let y = ctx.size().height / 2.0;
+        let line = Line::new((0.0, y), (ctx.size().width, y));
         let color = if *is_playing {
-            env.get(theme::GREY_200)
+            env.get(theme::GREY_400)
         } else {
             env.get(theme::GREY_500)
         };
         ctx.stroke_styled(line, &color, 1.0, &STYLE);
     })
-    .fix_height(1.0)
 }
 
 #[derive(Clone, Data, Lens)]

--- a/psst-gui/src/ui/playable.rs
+++ b/psst-gui/src/ui/playable.rs
@@ -84,7 +84,7 @@ pub fn is_playing_marker_widget() -> impl Widget<bool> {
         let y = ctx.size().height / 2.0;
         let line = Line::new((0.0, y), (ctx.size().width, y));
         let color = if *is_playing {
-            env.get(theme::GREY_400)
+            env.get(theme::GREY_300)
         } else {
             env.get(theme::GREY_500)
         };

--- a/psst-gui/src/ui/track.rs
+++ b/psst-gui/src/ui/track.rs
@@ -247,7 +247,7 @@ pub fn track_menu(
         let more_than_one_artist = track.artists.len() > 1;
         let title = if more_than_one_artist {
             LocalizedString::new("menu-item-show-artist-name")
-                .with_placeholder(format!("Go to Artist {}", artist_link.name))
+                .with_placeholder(format!("Go to Artist \"{}\"", artist_link.name))
         } else {
             LocalizedString::new("menu-item-show-artist").with_placeholder("Go to Artist")
         };

--- a/psst-gui/src/ui/track.rs
+++ b/psst-gui/src/ui/track.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use druid::{
-    widget::{CrossAxisAlignment, Either, Flex, Label, ViewSwitcher},
-    Env, LensExt, LocalizedString, Menu, MenuItem, Size, TextAlignment, Widget, WidgetExt,
+    widget::{CrossAxisAlignment, Either, Flex, Label, LineBreaking, ViewSwitcher},
+    Env, Lens, LensExt, LocalizedString, Menu, MenuItem, Size, TextAlignment, Widget, WidgetExt,
 };
 use psst_core::{
     audio::normalize::NormalizationLevel,
@@ -17,7 +17,7 @@ use crate::{
         QueueEntry, RecommendationsRequest, Track,
     },
     ui::playlist,
-    widget::{icons, Empty, MyWidgetExt, RemoteImage},
+    widget::{fill_between::FillBetween, icons, Empty, MyWidgetExt, RemoteImage},
 };
 
 use super::{
@@ -52,7 +52,7 @@ impl Display {
 
 pub fn playable_widget(track: &Track, display: Display) -> impl Widget<PlayRow<Arc<Track>>> {
     let mut main_row = Flex::row();
-    let mut major = Flex::row();
+    let mut major = Flex::row().cross_axis_alignment(CrossAxisAlignment::Center);
     let mut minor = Flex::row();
 
     if display.number {
@@ -73,7 +73,7 @@ pub fn playable_widget(track: &Track, display: Display) -> impl Widget<PlayRow<A
 
     if display.cover {
         let album_cover = rounded_cover_widget(theme::grid(4.0))
-            .padding_right(theme::grid(1.0)) // Instead of `add_default_spacer`.
+            .padding_right(theme::grid(1.0))
             .lens(PlayRow::item);
         main_row.add_child(Either::new(
             |row, _| row.ctx.show_track_cover,
@@ -85,36 +85,44 @@ pub fn playable_widget(track: &Track, display: Display) -> impl Widget<PlayRow<A
     if display.title {
         let track_name = Label::raw()
             .with_font(theme::UI_FONT_MEDIUM)
-            .lens(PlayRow::item.then(Track::name.in_arc()));
-        major.add_child(track_name);
+            .with_line_break_mode(LineBreaking::Clip)
+            .lens(PlayRow::item.then(Track::name.in_arc()))
+            .padding_right(theme::grid(1.0));
+        let is_playing = playable::is_playing_marker_widget().lens(PlayRow::is_playing);
+        major.add_flex_child(FillBetween::new(track_name, is_playing), 1.0);
     }
 
+    let mut minor_row = Flex::row();
     if track.explicit && (display.artist || display.album) {
         let icon = icons::EXPLICIT.scale(theme::ICON_SIZE_TINY);
-        minor.add_child(icon);
-        minor.add_spacer(theme::grid(0.5));
+        minor_row.add_child(icon);
+        minor_row.add_spacer(theme::grid(0.5));
     }
-
-    if display.artist {
-        let track_artists = Label::dynamic(|row: &PlayRow<Arc<Track>>, _| row.item.artist_names())
-            .with_text_size(theme::TEXT_SIZE_SMALL);
-        minor.add_child(track_artists);
-    }
-
-    if display.album {
-        let track_album = Label::raw()
-            .with_text_size(theme::TEXT_SIZE_SMALL)
-            .with_text_color(theme::PLACEHOLDER_COLOR)
-            .lens(PlayRow::item.then(Track::lens_album_name().in_arc()));
-        if display.artist {
-            minor.add_default_spacer();
+    let minor_label = Label::dynamic(move |row: &PlayRow<Arc<Track>>, _| {
+        let artist = if display.artist {
+            row.item.artist_names()
+        } else {
+            String::new()
+        };
+        let album = if display.album {
+            let mut album_name = String::new();
+            Track::lens_album_name().with(&row.item, |name| album_name = name.to_string());
+            album_name
+        } else {
+            String::new()
+        };
+        if !artist.is_empty() && !album.is_empty() {
+            format!("{} • {}", artist, album)
+        } else {
+            format!("{}{}", artist, album)
         }
-        minor.add_child(track_album);
-    }
+    })
+    .with_line_break_mode(LineBreaking::Clip)
+    .with_text_size(theme::TEXT_SIZE_SMALL)
+    .with_text_color(theme::PLACEHOLDER_COLOR);
 
-    let is_playing = playable::is_playing_marker_widget().lens(PlayRow::is_playing);
-    major.add_default_spacer();
-    major.add_flex_child(is_playing, 1.0);
+    minor_row.add_flex_child(minor_label, 1.0);
+    minor.add_flex_child(minor_row, 1.0);
 
     if display.popularity {
         let track_popularity = Label::<Arc<Track>>::dynamic(|track, _| {
@@ -175,7 +183,7 @@ pub fn playable_widget(track: &Track, display: Display) -> impl Widget<PlayRow<A
             1.0,
         )
         .with_default_spacer()
-        .with_child(saved)
+        .with_child(saved.center())
         .padding(theme::grid(1.0))
         .link()
         .active(|row: &PlayRow<Arc<Track>>, _env: &Env| {
@@ -184,9 +192,12 @@ pub fn playable_widget(track: &Track, display: Display) -> impl Widget<PlayRow<A
                 return *target_id == row.item.id;
             }
             // Otherwise check if it's playing or is the current track
-            row.is_playing || row.ctx.now_playing.as_ref().is_some_and(|playable| {
-                matches!(playable, Playable::Track(track) if track.id == row.item.id)
-            })
+            row.is_playing
+                || row
+                    .ctx
+                    .now_playing
+                    .as_ref()
+                    .is_some_and(|playable| matches!(playable, Playable::Track(track) if track.id == row.item.id))
         })
         .rounded(theme::BUTTON_BORDER_RADIUS)
         .context_menu(track_row_menu)
@@ -239,7 +250,7 @@ pub fn track_menu(
         let more_than_one_artist = track.artists.len() > 1;
         let title = if more_than_one_artist {
             LocalizedString::new("menu-item-show-artist-name")
-                .with_placeholder(format!("Go to Artist \"{}\"", artist_link.name))
+                .with_placeholder(format!("Go to Artist {}", artist_link.name))
         } else {
             LocalizedString::new("menu-item-show-artist").with_placeholder("Go to Artist")
         };

--- a/psst-gui/src/ui/track.rs
+++ b/psst-gui/src/ui/track.rs
@@ -192,12 +192,9 @@ pub fn playable_widget(track: &Track, display: Display) -> impl Widget<PlayRow<A
                 return *target_id == row.item.id;
             }
             // Otherwise check if it's playing or is the current track
-            row.is_playing
-                || row
-                    .ctx
-                    .now_playing
-                    .as_ref()
-                    .is_some_and(|playable| matches!(playable, Playable::Track(track) if track.id == row.item.id))
+            row.is_playing || row.ctx.now_playing.as_ref().is_some_and(|playable| {
+                matches!(playable, Playable::Track(track) if track.id == row.item.id)
+            })
         })
         .rounded(theme::BUTTON_BORDER_RADIUS)
         .context_menu(track_row_menu)

--- a/psst-gui/src/widget/fill_between.rs
+++ b/psst-gui/src/widget/fill_between.rs
@@ -1,0 +1,69 @@
+use druid::{
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
+    Point, Size, UpdateCtx, Widget, WidgetPod,
+};
+
+/// A widget that positions two children, allowing the right child to fill the remaining space.
+/// The left child is measured first, and the right child is given the rest of the available width.
+pub struct FillBetween<T: Data> {
+    left: WidgetPod<T, Box<dyn Widget<T>>>,
+    right: WidgetPod<T, Box<dyn Widget<T>>>,
+}
+
+impl<T: Data> FillBetween<T> {
+    pub fn new(left: impl Widget<T> + 'static, right: impl Widget<T> + 'static) -> Self {
+        Self {
+            left: WidgetPod::new(Box::new(left)),
+            right: WidgetPod::new(Box::new(right)),
+        }
+    }
+}
+
+impl<T: Data> Widget<T> for FillBetween<T> {
+    fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
+        self.right.event(ctx, event, data, env);
+        self.left.event(ctx, event, data, env);
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        self.right.lifecycle(ctx, event, data, env);
+        self.left.lifecycle(ctx, event, data, env);
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
+        self.left.update(ctx, data, env);
+        self.right.update(ctx, data, env);
+    }
+
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
+        let max_width = bc.max().width;
+
+        // Measure the left child with our max width constraint.
+        let left_bc = BoxConstraints::new(
+            Size::new(0.0, bc.min().height),
+            Size::new(max_width, bc.max().height),
+        );
+        let left_size = self.left.layout(ctx, &left_bc, data, env);
+
+        // Layout the right child in the remaining space.
+        let right_width = (max_width - left_size.width).max(0.0);
+        let right_bc = BoxConstraints::tight(Size::new(right_width, left_size.height));
+        let right_size = self.right.layout(ctx, &right_bc, data, env);
+
+        // Vertically center children.
+        let total_height = left_size.height.max(right_size.height);
+        let left_y = (total_height - left_size.height) / 2.0;
+        let right_y = (total_height - right_size.height) / 2.0;
+
+        self.left.set_origin(ctx, Point::new(0.0, left_y));
+        self.right
+            .set_origin(ctx, Point::new(left_size.width, right_y));
+
+        Size::new(max_width, total_height)
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
+        self.left.paint(ctx, data, env);
+        self.right.paint(ctx, data, env);
+    }
+}

--- a/psst-gui/src/widget/mod.rs
+++ b/psst-gui/src/widget/mod.rs
@@ -1,6 +1,7 @@
 mod checkbox;
 mod dispatcher;
 mod empty;
+pub mod fill_between;
 pub mod icons;
 mod link;
 mod maybe;


### PR DESCRIPTION
I'm hoping to solve that issue where long titles and album details are not clipped.

- Refactor the track widget layout for better maintainability and ability to truncate the top and bottom row
- Fix the "now playing" dot highhighting in the album view
- Make the "now playing" marker a little lighter when active
