### PR TITLE
chore: Remove unused import `LineBreaking` from track.rs

### DIFF
--- a/psst-gui/src/ui/track.rs
+++ b/psst-gui/src/ui/track.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use druid::{
-    widget::{CrossAxisAlignment, Either, Flex, Label, LineBreaking, ViewSwitcher},
+    widget::{CrossAxisAlignment, Either, Flex, Label, ViewSwitcher},
     LensExt, LocalizedString, Menu, MenuItem, Size, TextAlignment, Widget, WidgetExt,
 };
 use psst_core::{


### PR DESCRIPTION
Fixes this compiler warning using the suggested fix.

```
warning: unused import: `LineBreaking`
 --> psst-gui/src/ui/track.rs:4:55
  |
4 |     widget::{CrossAxisAlignment, Either, Flex, Label, LineBreaking, ViewSwitcher},
  |                                                       ^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: `psst-gui` (bin "psst-gui") generated 1 warning (run `cargo fix --bin "psst-gui"` to apply 1 suggestion)                                                               
    Finished `release` profile [optimized] target(s) in 4m 25s
```