### PR TITLE
Kiosk mode

### DIFF
--- a/psst-gui/src/data/config.rs
+++ b/psst-gui/src/data/config.rs
@@ -100,6 +100,7 @@ pub struct Config {
     pub sort_criteria: SortCriteria,
     pub paginated_limit: usize,
     pub seek_duration: usize,
+    pub kiosk_mode: bool,
 }
 
 impl Default for Config {
@@ -118,6 +119,7 @@ impl Default for Config {
             sort_criteria: Default::default(),
             paginated_limit: 500,
             seek_duration: 10,
+            kiosk_mode: false,
         }
     }
 }

--- a/psst-gui/src/delegate.rs
+++ b/psst-gui/src/delegate.rs
@@ -71,13 +71,13 @@ impl Delegate {
         }
     }
 
-    fn show_preferences(&mut self, config: &Config, ctx: &mut DelegateCtx) {
+    fn show_preferences(&mut self, ctx: &mut DelegateCtx) {
         match self.preferences_window {
             Some(id) => {
                 ctx.submit_command(commands::SHOW_WINDOW.to(id));
             }
             None => {
-                let window = ui::preferences_window(config);
+                let window = ui::preferences_window();
                 self.preferences_window.replace(window.id);
                 ctx.new_window(window);
             }
@@ -113,7 +113,7 @@ impl AppDelegate<AppState> for Delegate {
             self.show_account_setup(ctx);
             Handled::Yes
         } else if cmd.is(commands::SHOW_PREFERENCES) {
-            self.show_preferences(&data.config, ctx);
+            self.show_preferences(ctx);
             Handled::Yes
         } else if cmd.is(cmd::CLOSE_ALL_WINDOWS) {
             self.close_all_windows(ctx);

--- a/psst-gui/src/delegate.rs
+++ b/psst-gui/src/delegate.rs
@@ -71,13 +71,13 @@ impl Delegate {
         }
     }
 
-    fn show_preferences(&mut self, ctx: &mut DelegateCtx) {
+    fn show_preferences(&mut self, config: &Config, ctx: &mut DelegateCtx) {
         match self.preferences_window {
             Some(id) => {
                 ctx.submit_command(commands::SHOW_WINDOW.to(id));
             }
             None => {
-                let window = ui::preferences_window();
+                let window = ui::preferences_window(config);
                 self.preferences_window.replace(window.id);
                 ctx.new_window(window);
             }
@@ -113,7 +113,7 @@ impl AppDelegate<AppState> for Delegate {
             self.show_account_setup(ctx);
             Handled::Yes
         } else if cmd.is(commands::SHOW_PREFERENCES) {
-            self.show_preferences(ctx);
+            self.show_preferences(&data.config, ctx);
             Handled::Yes
         } else if cmd.is(cmd::CLOSE_ALL_WINDOWS) {
             self.close_all_windows(ctx);

--- a/psst-gui/src/main.rs
+++ b/psst-gui/src/main.rs
@@ -46,29 +46,28 @@ fn main() {
         paginated_limit,
     )
     .install_as_global();
-
-    let delegate;
-    let launcher;
-    if state.config.has_credentials() {
+    let (delegate, launcher) = if state.config.has_credentials() {
         // Credentials are configured, open the main window.
         let window = ui::main_window(&state.config);
-        delegate = Delegate::with_main(window.id);
-        launcher = AppLauncher::with_window(window).configure_env(ui::theme::setup);
+        let delegate = Delegate::with_main(window.id);
 
         // Load user's local tracks for the WebApi.
         WebApi::global().load_local_tracks(state.config.username().unwrap());
+
+        (delegate, AppLauncher::with_window(window))
     } else {
-        // No configured credentials, open the account setup.
-        let window = ui::account_setup_window();
-
-        if state.config.kiosk_mode {
-            let window = ui::kiosk_setup_window();
+        // No configured credentials, open the setup window.
+        let window = if state.config.kiosk_mode {
+            ui::kiosk_setup_window()
         } else {
-        }
+            ui::account_setup_window()
+        };
+        let delegate = Delegate::with_preferences(window.id);
 
-        delegate = Delegate::with_preferences(window.id);
-        launcher = AppLauncher::with_window(window).configure_env(ui::theme::setup);
+        (delegate, AppLauncher::with_window(window))
     };
+
+    let launcher = launcher.configure_env(ui::theme::setup);
 
     launcher
         .delegate(delegate)

--- a/psst-gui/src/main.rs
+++ b/psst-gui/src/main.rs
@@ -12,8 +12,8 @@ mod widget;
 
 use druid::AppLauncher;
 use env_logger::{Builder, Env};
-use webapi::WebApi;
 use std::env;
+use webapi::WebApi;
 
 use crate::{
     data::{AppState, Config},
@@ -37,10 +37,7 @@ fn main() {
     let mut state = AppState::default_with_config(config);
 
     let args: Vec<String> = env::args().collect();
-    state.config.kiosk_mode = false;
-    if !args.is_empty() && (args.contains(&"-k".to_string()) || args.contains(&"--kiosk".to_string())) {
-        state.config.kiosk_mode = true;
-    }
+    state.config.kiosk_mode = args.iter().any(|arg| arg == "-k" || arg == "--kiosk");
 
     WebApi::new(
         state.session.clone(),
@@ -63,10 +60,10 @@ fn main() {
     } else {
         // No configured credentials, open the account setup.
         let mut window = ui::account_setup_window();
-        
+
         if state.config.kiosk_mode {
             window = ui::kiosk_setup_window();
-        } 
+        }
 
         delegate = Delegate::with_preferences(window.id);
         launcher = AppLauncher::with_window(window).configure_env(ui::theme::setup);

--- a/psst-gui/src/main.rs
+++ b/psst-gui/src/main.rs
@@ -59,10 +59,12 @@ fn main() {
         WebApi::global().load_local_tracks(state.config.username().unwrap());
     } else {
         // No configured credentials, open the account setup.
-        let mut window = ui::account_setup_window();
+        let window = ui::account_setup_window();
 
         if state.config.kiosk_mode {
-            window = ui::kiosk_setup_window();
+           let window = ui::kiosk_setup_window();
+        } else {
+
         }
 
         delegate = Delegate::with_preferences(window.id);

--- a/psst-gui/src/main.rs
+++ b/psst-gui/src/main.rs
@@ -62,9 +62,8 @@ fn main() {
         let window = ui::account_setup_window();
 
         if state.config.kiosk_mode {
-           let window = ui::kiosk_setup_window();
+            let window = ui::kiosk_setup_window();
         } else {
-
         }
 
         delegate = Delegate::with_preferences(window.id);

--- a/psst-gui/src/main.rs
+++ b/psst-gui/src/main.rs
@@ -38,7 +38,7 @@ fn main() {
 
     let args: Vec<String> = env::args().collect();
     state.config.kiosk_mode = false;
-    if !args.is_empty() && (args.contains(&"-k".to_string()) || args.contains(&"-kiosk".to_string())) {
+    if !args.is_empty() && (args.contains(&"-k".to_string()) || args.contains(&"--kiosk".to_string())) {
         state.config.kiosk_mode = true;
     }
 

--- a/psst-gui/src/ui/menu.rs
+++ b/psst-gui/src/ui/menu.rs
@@ -5,8 +5,8 @@ use crate::{
     data::{AppState, Nav},
 };
 
-pub fn main_menu(_window: Option<WindowId>, _data: &AppState, _env: &Env) -> Menu<AppState> {
-    if cfg!(target_os = "macos") {
+pub fn main_menu(_window: Option<WindowId>, data: &AppState, _env: &Env) -> Menu<AppState> {
+    if cfg!(target_os = "macos") && !data.config.kiosk_mode {
         Menu::empty().entry(mac_app_menu())
     } else {
         Menu::empty()

--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -46,8 +46,7 @@ pub mod utils;
 pub fn main_window(config: &Config) -> WindowDesc<AppState> {
     let mut win = WindowDesc::new(root_widget(config))
         .title(compute_main_window_title)
-        .show_title(false)
-        .transparent_titlebar(true);
+        .show_title(false);
 
     if config.kiosk_mode {
         win = win
@@ -65,7 +64,8 @@ pub fn main_window(config: &Config) -> WindowDesc<AppState> {
     } else {
         win = win
             .window_size(config.window_size)
-            .with_min_size((theme::grid(65.0), theme::grid(50.0)));
+            .with_min_size((theme::grid(65.0), theme::grid(50.0)))
+            .transparent_titlebar(true);
     }
 
     if cfg!(target_os = "macos") {

--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -89,7 +89,6 @@ pub fn preferences_window(config: &Config) -> WindowDesc<AppState> {
 
     let mut win = WindowDesc::new(preferences_widget())
         .title("Preferences")
-        .resizable(false)
         .show_title(false)
         .transparent_titlebar(true);
 
@@ -108,6 +107,7 @@ pub fn preferences_window(config: &Config) -> WindowDesc<AppState> {
             .show_titlebar(false);
     } else {
         win = win.window_size(win_size)
+            .resizable(false)
     }
     if cfg!(target_os = "macos") {
         win.menu(menu::main_menu)
@@ -131,10 +131,8 @@ pub fn account_setup_window() -> WindowDesc<AppState> {
 }
 
 pub fn kiosk_setup_window() -> WindowDesc<AppState> {
-
     let mut win = WindowDesc::new(kiosk_setup_widget())
         .title("Setup")
-        .resizable(false)
         .show_title(false)
         .set_window_state(WindowState::Maximized)
         .show_titlebar(false)
@@ -144,7 +142,8 @@ pub fn kiosk_setup_window() -> WindowDesc<AppState> {
         let work_area = monitor.virtual_work_rect();
         win = win
             .window_size(work_area.size())
-            .set_position(druid::Point::new(0.0, 0.0));
+            .set_position(druid::Point::new(0.0, 0.0))
+            .resizable(false);
     }
         
     if cfg!(target_os = "macos") {

--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -85,7 +85,7 @@ pub fn preferences_window() -> WindowDesc<AppState> {
     } else {
         win_size
     };
-    
+
     let win = WindowDesc::new(preferences_widget())
         .title("Preferences")
         .window_size(win_size)

--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -76,9 +76,16 @@ pub fn main_window(config: &Config) -> WindowDesc<AppState> {
 }
 
 pub fn preferences_window() -> WindowDesc<AppState> {
-    // Change this
     let win_size = (theme::grid(50.0), theme::grid(55.0));
 
+    // On Windows, the window size includes the titlebar.
+    let win_size = if cfg!(target_os = "windows") {
+        const WINDOWS_TITLEBAR_OFFSET: f64 = 56.0;
+        (win_size.0, win_size.1 + WINDOWS_TITLEBAR_OFFSET)
+    } else {
+        win_size
+    };
+    
     let win = WindowDesc::new(preferences_widget())
         .title("Preferences")
         .window_size(win_size)

--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -75,40 +75,17 @@ pub fn main_window(config: &Config) -> WindowDesc<AppState> {
     }
 }
 
-pub fn preferences_window(config: &Config) -> WindowDesc<AppState> {
+pub fn preferences_window() -> WindowDesc<AppState> {
     // Change this
     let win_size = (theme::grid(50.0), theme::grid(55.0));
 
-    // On Windows, the window size includes the titlebar.
-    let win_size = if cfg!(target_os = "windows") {
-        const WINDOWS_TITLEBAR_OFFSET: f64 = 56.0;
-        (win_size.0, win_size.1 + WINDOWS_TITLEBAR_OFFSET)
-    } else {
-        win_size
-    };
-
-    let mut win = WindowDesc::new(preferences_widget())
+    let win = WindowDesc::new(preferences_widget())
         .title("Preferences")
+        .window_size(win_size)
+        .resizable(false)
         .show_title(false)
+        .set_always_on_top(true)
         .transparent_titlebar(true);
-
-    if config.kiosk_mode {
-        if let Some(monitor) = druid::Screen::get_monitors().first() {
-            let work_area = monitor.virtual_work_rect();
-            win = win
-                .window_size(work_area.size())
-                .set_position(druid::Point::new(0.0, 0.0));
-        }
-
-        win = win
-            .set_window_state(WindowState::Maximized)
-            .resizable(false)
-            .set_always_on_top(true)
-            .show_titlebar(false);
-    } else {
-        win = win.window_size(win_size)
-            .resizable(false)
-    }
     if cfg!(target_os = "macos") {
         win.menu(menu::main_menu)
     } else {
@@ -131,21 +108,12 @@ pub fn account_setup_window() -> WindowDesc<AppState> {
 }
 
 pub fn kiosk_setup_window() -> WindowDesc<AppState> {
-    let mut win = WindowDesc::new(kiosk_setup_widget())
+    let win = WindowDesc::new(kiosk_setup_widget())
         .title("Setup")
+        .resizable(false)
         .show_title(false)
-        .set_window_state(WindowState::Maximized)
-        .show_titlebar(false)
+        .window_size((theme::grid(50.0), theme::grid(45.0)))
         .transparent_titlebar(true);
-
-    if let Some(monitor) = druid::Screen::get_monitors().first() {
-        let work_area = monitor.virtual_work_rect();
-        win = win
-            .window_size(work_area.size())
-            .set_position(druid::Point::new(0.0, 0.0))
-            .resizable(false);
-    }
-        
     if cfg!(target_os = "macos") {
         win.menu(menu::main_menu)
     } else {

--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -53,8 +53,7 @@ pub fn main_window(config: &Config) -> WindowDesc<AppState> {
         win = win
             .set_window_state(WindowState::Maximized)
             .resizable(false)
-            .show_titlebar(false)
-            .set_always_on_top(true);
+            .show_titlebar(false);
 
         // Set the window size to the primary monitor's work area and position it at (0, 0)
         if let Some(monitor) = druid::Screen::get_monitors().first() {
@@ -95,6 +94,13 @@ pub fn preferences_window(config: &Config) -> WindowDesc<AppState> {
         .transparent_titlebar(true);
 
     if config.kiosk_mode {
+        if let Some(monitor) = druid::Screen::get_monitors().first() {
+            let work_area = monitor.virtual_work_rect();
+            win = win
+                .window_size(work_area.size())
+                .set_position(druid::Point::new(0.0, 0.0));
+        }
+
         win = win
             .set_window_state(WindowState::Maximized)
             .resizable(false)
@@ -125,13 +131,22 @@ pub fn account_setup_window() -> WindowDesc<AppState> {
 }
 
 pub fn kiosk_setup_window() -> WindowDesc<AppState> {
-    let win = WindowDesc::new(kiosk_setup_widget())
+
+    let mut win = WindowDesc::new(kiosk_setup_widget())
         .title("Setup")
         .resizable(false)
         .show_title(false)
         .set_window_state(WindowState::Maximized)
         .show_titlebar(false)
         .transparent_titlebar(true);
+
+    if let Some(monitor) = druid::Screen::get_monitors().first() {
+        let work_area = monitor.virtual_work_rect();
+        win = win
+            .window_size(work_area.size())
+            .set_position(druid::Point::new(0.0, 0.0));
+    }
+        
     if cfg!(target_os = "macos") {
         win.menu(menu::main_menu)
     } else {

--- a/psst-gui/src/ui/preferences.rs
+++ b/psst-gui/src/ui/preferences.rs
@@ -270,10 +270,11 @@ fn general_tab_widget() -> impl Widget<AppState> {
                 .lens(AppState::config.then(Config::paginated_limit)),
         );
 
-    col = col.with_default_spacer()
-        .with_child(Button::new("Done")
-        .align_right()
-        .on_click(|ctx, _,  _| {ctx.submit_command(commands::CLOSE_WINDOW)}));
+    col = col.with_default_spacer().with_child(
+        Button::new("Done")
+            .align_right()
+            .on_click(|ctx, _, _| ctx.submit_command(commands::CLOSE_WINDOW)),
+    );
 
     col
 }
@@ -323,13 +324,16 @@ fn account_tab_widget(tab: AccountTab) -> impl Widget<AppState> {
         );
 
     if matches!(tab, AccountTab::InPreferences) {
-        col = col.with_child(Button::new("Log Out").on_left_click(|ctx, _, _, _| {
-            ctx.submit_command(cmd::LOG_OUT);
-        }))        
-        .with_default_spacer()
-        .with_child(Button::new("Done")
-        .align_right()
-        .on_click(|ctx, _,  _| {ctx.submit_command(commands::CLOSE_WINDOW)}))
+        col = col
+            .with_child(Button::new("Log Out").on_left_click(|ctx, _, _, _| {
+                ctx.submit_command(cmd::LOG_OUT);
+            }))
+            .with_default_spacer()
+            .with_child(
+                Button::new("Done")
+                    .align_right()
+                    .on_click(|ctx, _, _| ctx.submit_command(commands::CLOSE_WINDOW)),
+            )
     }
 
     col.controller(Authenticate::new(tab))
@@ -481,10 +485,11 @@ fn cache_tab_widget() -> impl Widget<AppState> {
                 }
             },
         ));
-    col = col.with_default_spacer()
-        .with_child(Button::new("Done")
-        .align_right()
-        .on_click(|ctx, _,  _| {ctx.submit_command(commands::CLOSE_WINDOW)}));
+    col = col.with_default_spacer().with_child(
+        Button::new("Done")
+            .align_right()
+            .on_click(|ctx, _, _| ctx.submit_command(commands::CLOSE_WINDOW)),
+    );
 
     col.controller(MeasureCacheSize::new())
         .lens(AppState::preferences)
@@ -578,7 +583,9 @@ fn about_tab_widget() -> impl Widget<AppState> {
         .with_child(build_time)
         .with_child(remote_url)
         .with_default_spacer()
-        .with_child(Button::new("Done")
-        .align_right()
-        .on_click(|ctx, _,  _| {ctx.submit_command(commands::CLOSE_WINDOW)}))
+        .with_child(
+            Button::new("Done")
+                .align_right()
+                .on_click(|ctx, _, _| ctx.submit_command(commands::CLOSE_WINDOW)),
+        )
 }

--- a/psst-gui/src/ui/preferences.rs
+++ b/psst-gui/src/ui/preferences.rs
@@ -430,9 +430,9 @@ impl<W: Widget<AppState>> Controller<AppState, W> for Authenticate {
                             ctx.submit_command(cmd::SESSION_CONNECT);
                         }
                         AccountTab::KioskSetup => {
-                            ctx.submit_command(cmd::SHOW_MAIN);
                             ctx.submit_command(commands::CLOSE_WINDOW);
                             ctx.submit_command(commands::SHOW_PREFERENCES);
+                            ctx.submit_command(cmd::SHOW_MAIN);
                         }
                     }
                 }

--- a/psst-gui/src/ui/preferences.rs
+++ b/psst-gui/src/ui/preferences.rs
@@ -47,6 +47,29 @@ pub fn account_setup_widget() -> impl Widget<AppState> {
         .padding(theme::grid(4.0))
 }
 
+pub fn kiosk_setup_widget() -> impl Widget<AppState> {
+    Flex::column()
+        .must_fill_main_axis(true)
+        .cross_axis_alignment(CrossAxisAlignment::Start)
+        .with_spacer(theme::grid(2.0))
+        .with_child(
+            Label::new("Please insert your Spotify Premium credentials.")
+                .with_font(theme::UI_FONT_MEDIUM)
+                .with_line_break_mode(LineBreaking::WordWrap),
+        )
+        .with_spacer(theme::grid(2.0))
+        .with_child(
+            Label::new(
+                "Psst connects only to the official servers, and does not store your password.",
+            )
+            .with_text_color(theme::PLACEHOLDER_COLOR)
+            .with_line_break_mode(LineBreaking::WordWrap),
+        )
+        .with_spacer(theme::grid(6.0))
+        .with_child(account_tab_widget(AccountTab::KioskSetup).expand_width())
+        .padding(theme::grid(4.0))
+}
+
 pub fn preferences_widget() -> impl Widget<AppState> {
     const PROPAGATE_FLAGS: Selector = Selector::new("app.preferences.propagate-flags");
 
@@ -247,6 +270,11 @@ fn general_tab_widget() -> impl Widget<AppState> {
                 .lens(AppState::config.then(Config::paginated_limit)),
         );
 
+    col = col.with_default_spacer()
+        .with_child(Button::new("Done")
+        .align_right()
+        .on_click(|ctx, _,  _| {ctx.submit_command(commands::CLOSE_WINDOW)}));
+
     col
 }
 
@@ -254,12 +282,14 @@ fn general_tab_widget() -> impl Widget<AppState> {
 enum AccountTab {
     FirstSetup,
     InPreferences,
+    KioskSetup,
 }
 
 fn account_tab_widget(tab: AccountTab) -> impl Widget<AppState> {
     let mut col = Flex::column().cross_axis_alignment(match tab {
         AccountTab::FirstSetup => CrossAxisAlignment::Center,
         AccountTab::InPreferences => CrossAxisAlignment::Start,
+        AccountTab::KioskSetup => CrossAxisAlignment::Start,
     });
 
     if matches!(tab, AccountTab::InPreferences) {
@@ -295,7 +325,11 @@ fn account_tab_widget(tab: AccountTab) -> impl Widget<AppState> {
     if matches!(tab, AccountTab::InPreferences) {
         col = col.with_child(Button::new("Log Out").on_left_click(|ctx, _, _, _| {
             ctx.submit_command(cmd::LOG_OUT);
-        }))
+        }))        
+        .with_default_spacer()
+        .with_child(Button::new("Done")
+        .align_right()
+        .on_click(|ctx, _,  _| {ctx.submit_command(commands::CLOSE_WINDOW)}))
     }
 
     col.controller(Authenticate::new(tab))
@@ -391,6 +425,11 @@ impl<W: Widget<AppState>> Controller<AppState, W> for Authenticate {
                         AccountTab::InPreferences => {
                             ctx.submit_command(cmd::SESSION_CONNECT);
                         }
+                        AccountTab::KioskSetup => {
+                            ctx.submit_command(cmd::SHOW_MAIN);
+                            ctx.submit_command(commands::CLOSE_WINDOW);
+                            ctx.submit_command(commands::SHOW_PREFERENCES);
+                        }
                     }
                 }
                 data.preferences.auth.access_token.clear();
@@ -442,6 +481,10 @@ fn cache_tab_widget() -> impl Widget<AppState> {
                 }
             },
         ));
+    col = col.with_default_spacer()
+        .with_child(Button::new("Done")
+        .align_right()
+        .on_click(|ctx, _,  _| {ctx.submit_command(commands::CLOSE_WINDOW)}));
 
     col.controller(MeasureCacheSize::new())
         .lens(AppState::preferences)
@@ -534,4 +577,8 @@ fn about_tab_widget() -> impl Widget<AppState> {
         .with_child(commit_hash)
         .with_child(build_time)
         .with_child(remote_url)
+        .with_default_spacer()
+        .with_child(Button::new("Done")
+        .align_right()
+        .on_click(|ctx, _,  _| {ctx.submit_command(commands::CLOSE_WINDOW)}))
 }

--- a/psst-gui/src/ui/user.rs
+++ b/psst-gui/src/ui/user.rs
@@ -7,7 +7,10 @@ use druid::{
 use crate::{
     data::{AppState, Library, UserProfile},
     webapi::WebApi,
-    widget::{icons::{self, SvgIcon}, Async, Empty, MyWidgetExt},
+    widget::{
+        icons::{self, SvgIcon},
+        Async, Empty, MyWidgetExt,
+    },
 };
 
 use super::theme;
@@ -51,13 +54,11 @@ pub fn user_widget() -> impl Widget<AppState> {
                 .with_child(user_profile)
                 .padding(theme::grid(1.0)),
         )
-        .with_child(
-            Either::new(
-                |data: &AppState, _| !data.config.kiosk_mode,
-                preferences_widget(&icons::PREFERENCES),
-                Empty,
-            )
-        )
+        .with_child(Either::new(
+            |data: &AppState, _| !data.config.kiosk_mode,
+            preferences_widget(&icons::PREFERENCES),
+            Empty,
+        ))
 }
 
 fn preferences_widget<T: Data>(svg: &SvgIcon) -> impl Widget<T> {

--- a/psst-gui/src/ui/user.rs
+++ b/psst-gui/src/ui/user.rs
@@ -7,7 +7,7 @@ use druid::{
 use crate::{
     data::{AppState, Library, UserProfile},
     webapi::WebApi,
-    widget::{icons, icons::SvgIcon, Async, Empty, MyWidgetExt},
+    widget::{icons::{self, SvgIcon}, Async, Empty, MyWidgetExt},
 };
 
 use super::theme;
@@ -51,7 +51,13 @@ pub fn user_widget() -> impl Widget<AppState> {
                 .with_child(user_profile)
                 .padding(theme::grid(1.0)),
         )
-        .with_child(preferences_widget(&icons::PREFERENCES))
+        .with_child(
+            Either::new(
+                |data: &AppState, _| !data.config.kiosk_mode,
+                preferences_widget(&icons::PREFERENCES),
+                Empty,
+            )
+        )
 }
 
 fn preferences_widget<T: Data>(svg: &SvgIcon) -> impl Widget<T> {


### PR DESCRIPTION
This is a PR for issue #528. It is essentially done and can be run by adding the system command psst-gui -- --k or psst-gui -- --kiosk to run in kiosk mode.

What I have implemented is that it opens everything in full screen without window decorations. Additionally, the settings are shown directly after logging in with a button to close it, so the settings are set but cannot be changed as I removed the button to access settings.

I have it so that when this kiosk mode is enabled, the keyboard shortcuts don't work (even though they also only work on Mac), and it cannot be exited in this way.
 
I think that the keyboard shortcuts to access the desktop need to be done on the system level because I can't interrupt things like clicking the super key. Correct me if I'm wrong. If I'm not, this should be ready to be merged with the MR with @jacksongoode's approval.