### PR TITLE
Fix for lyrics without timestamp

### DIFF
--- a/psst-gui/src/ui/lyrics.rs
+++ b/psst-gui/src/ui/lyrics.rs
@@ -75,10 +75,11 @@ fn track_lyrics_widget() -> impl Widget<AppState> {
                     .link()
                     .rounded(theme::BUTTON_BORDER_RADIUS)
                     .on_left_click(|ctx, _, c, _| {
-                        ctx.submit_command(
-                            cmd::SKIP_TO_POSITION
-                                .with(c.data.start_time_ms.parse::<u64>().unwrap()),
-                        )
+                        if c.data.start_time_ms.parse::<u64>().unwrap() != 0 {
+                            ctx.submit_command(
+                                cmd::SKIP_TO_POSITION.with(c.data.start_time_ms.parse::<u64>().unwrap())
+                            )
+                        } 
                     })
             })
         },


### PR DESCRIPTION
Fix #544 by detecting if the song lyrics time is set at 0.