### PR TITLE
Fix Linux compilation failing due to infinite recursion

### DIFF
--- a/psst-gui/src/data/track.rs
+++ b/psst-gui/src/data/track.rs
@@ -27,7 +27,7 @@ pub struct Track {
     pub popularity: Option<u32>,
     #[serde(skip)]
     pub track_pos: usize,
-    pub lyrics: Option<Vector<TrackLines>>,
+    pub lyrics: Option<Arc<[TrackLines]>>,
 }
 
 impl Track {


### PR DESCRIPTION
Right now, on current main, I can't compile `psst-gui` due to an issue with overflowing trait requirements:

```sh
error[E0275]: overflow evaluating the requirement `sized_chunks::sized_chunk::Chunk<TrackLines>: std::marker::Sync`
   --> psst-gui/src/ui/search.rs:52:6
    |
52  |     .on_command_async(
    |      ^^^^^^^^^^^^^^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`psst_gui`)
    = note: required for `std::sync::Arc<sized_chunks::sized_chunk::Chunk<TrackLines>>` to implement `Send`
note: required because it appears within the type `im::fakepool::Arc<sized_chunks::sized_chunk::Chunk<TrackLines>>`
   --> /home/june/.cargo/registry/src/index.crates.io-6f17d22bba15001f/im-15.1.0/./src/fakepool.rs:128:19
    |
128 | pub(crate) struct Arc<A>(RArc<A>);
    |                   ^^^
note: required because it appears within the type `im::nodes::rrb::Entry<TrackLines>`
   --> /home/june/.cargo/registry/src/index.crates.io-6f17d22bba15001f/im-15.1.0/./src/nodes/rrb.rs:162:6
    |
162 | enum Entry<A> {
    |      ^^^^^
note: required because it appears within the type `im::nodes::rrb::Node<TrackLines>`
   --> /home/june/.cargo/registry/src/index.crates.io-6f17d22bba15001f/im-15.1.0/./src/nodes/rrb.rs:244:19
    |
244 | pub(crate) struct Node<A> {
    |                   ^^^^
note: required because it appears within the type `sized_chunks::types::SizeOdd<im::nodes::rrb::Node<TrackLines>, ()>`
   --> /home/june/.cargo/registry/src/index.crates.io-6f17d22bba15001f/sized-chunks-0.6.5/src/types.rs:36:12
    |
36  | pub struct SizeOdd<A, B> {
    |            ^^^^^^^
note: required because it appears within the type `sized_chunks::types::SizeEven<im::nodes::rrb::Node<TrackLines>, sized_chunks::types::SizeOdd<im::nodes::rrb::Node<TrackLines>, ()>>`
   --> /home/june/.cargo/registry/src/index.crates.io-6f17d22bba15001f/sized-chunks-0.6.5/src/types.rs:28:12
    |
28  | pub struct SizeEven<A, B> {
    |            ^^^^^^^^
note: required because it appears within the type `sized_chunks::types::SizeEven<im::nodes::rrb::Node<TrackLines>, sized_chunks::types::SizeEven<im::nodes::rrb::Node<TrackLines>, sized_chunks::types::SizeOdd<im::nodes::rrb::Node<TrackLines>, ()>>>`
```

It seems that switching this `Vector` to an `Arc<[]>` fixes the compilation issue. It also runs fine and I've verified that I can listen to music and view lyrics and such with this change. I'm not super familiar with `druid`, so I'm not certain if this `Vector` is needed for any sort of reactivity or whatever, but it seems to work fine for me.