### PR TITLE
Deduplicate code and fix a few clippy complaints

### DIFF
--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -474,17 +474,12 @@ fn route_icon_widget() -> impl Widget<Nav> {
         |nav: &Nav, _, _| {
             let icon = |icon: &SvgIcon| icon.scale(theme::ICON_SIZE_MEDIUM);
             match &nav {
-                Nav::Home => Empty.boxed(),
-                Nav::Lyrics => Empty.boxed(),
-                Nav::SavedTracks => Empty.boxed(),
-                Nav::SavedAlbums => Empty.boxed(),
-                Nav::SavedShows => Empty.boxed(),
-                Nav::SearchResults(_) => icon(&icons::SEARCH).boxed(),
+                Nav::Home | Nav::Lyrics | Nav::SavedTracks | Nav::SavedAlbums | Nav::SavedShows => Empty.boxed(),
+                Nav::SearchResults(_) | Nav::Recommendations(_) => icon(&icons::SEARCH).boxed(),
                 Nav::AlbumDetail(_) => icon(&icons::ALBUM).boxed(),
                 Nav::ArtistDetail(_) => icon(&icons::ARTIST).boxed(),
                 Nav::PlaylistDetail(_) => icon(&icons::PLAYLIST).boxed(),
                 Nav::ShowDetail(_) => icon(&icons::PODCAST).boxed(),
-                Nav::Recommendations(_) => icon(&icons::SEARCH).boxed(),
             }
         },
     )

--- a/psst-gui/src/ui/playlist.rs
+++ b/psst-gui/src/ui/playlist.rs
@@ -437,12 +437,12 @@ pub fn detail_widget() -> impl Widget<AppState> {
         },
         |_, data, d| data.playlist_detail.tracks.defer(d.0),
         |_, data, (d, r)| {
-            let r = r.map(|tracks| PlaylistTracks {
+            let tracks = PlaylistTracks {
                 id: d.0.id.clone(),
                 name: d.0.name.clone(),
-                tracks,
-            });
-            data.playlist_detail.tracks.update((d.0, r))
+                tracks: r,
+            };
+            data.playlist_detail.tracks.update((d.0, Ok(tracks)))
         },
     )
 }
@@ -450,44 +450,41 @@ pub fn detail_widget() -> impl Widget<AppState> {
 fn sort_playlist(
     data: &AppState,
     result: Result<Vector<Arc<Track>>, Error>,
-) -> Result<Vector<Arc<Track>>, Error> {
+) -> Vector<Arc<Track>> {
     let sort_criteria = data.config.sort_criteria;
     let sort_order = data.config.sort_order;
 
     let playlist = result.unwrap_or_else(|_| Vector::new());
 
-    let mut sorted_playlist: Vector<Arc<Track>> = playlist
+    let sorted_playlist: Vector<Arc<Track>> = playlist
         .into_iter()
         .sorted_by(|a, b| {
-            let mut method = match sort_criteria {
+            let method = match sort_criteria {
                 SortCriteria::Title => a.name.cmp(&b.name),
                 SortCriteria::Artist => a.artist_name().cmp(&b.artist_name()),
                 SortCriteria::Album => a.album_name().cmp(&b.album_name()),
                 SortCriteria::Duration => a.duration.cmp(&b.duration),
-                _ => Ordering::Equal,
+                SortCriteria::DateAdded => Ordering::Equal,
             };
-            method = if sort_order == SortOrder::Descending {
+
+            if sort_order == SortOrder::Descending {
                 method.reverse()
             } else {
                 method
-            };
-            method
+            }
         })
         .collect();
 
-    sorted_playlist =
-        if sort_criteria == SortCriteria::DateAdded && sort_order == SortOrder::Descending {
-            sorted_playlist.into_iter().rev().collect()
-        } else {
-            sorted_playlist
-        };
-
-    Ok(sorted_playlist)
+    if sort_criteria == SortCriteria::DateAdded && sort_order == SortOrder::Descending {
+        sorted_playlist.into_iter().rev().collect()
+    } else {
+        sorted_playlist
+    }
 }
 
 fn playlist_menu_ctx(playlist: &WithCtx<Playlist>) -> Menu<AppState> {
-    let library = &playlist.ctx.to_owned().library;
-    let playlist = &playlist.to_owned().data;
+    let library = &playlist.ctx.library;
+    let playlist = &playlist.data;
 
     let mut menu = Menu::empty();
 

--- a/psst-gui/src/ui/preferences.rs
+++ b/psst-gui/src/ui/preferences.rs
@@ -88,7 +88,7 @@ pub fn preferences_widget() -> impl Widget<AppState> {
                 ctx.submit_command(PROPAGATE_FLAGS);
             }
         })
-        .on_command(PROPAGATE_FLAGS, |_, _, data| {
+        .on_command(PROPAGATE_FLAGS, |_, (), data| {
             data.common_ctx_mut().show_track_cover = data.config.show_track_cover;
         })
         .scroll()

--- a/psst-gui/src/webapi/local.rs
+++ b/psst-gui/src/webapi/local.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 use crate::data::{config::Config, AlbumLink, ArtistLink, Image, Track, TrackId};
 use psst_core::item_id::ItemId;
 
-/**
+/*
  * All local files registered by the Spotify file can be found in the file
  * located at: <Spotify config>/Users/<username>-user/local-files.bnk
  *

--- a/psst-gui/src/widget/link.rs
+++ b/psst-gui/src/widget/link.rs
@@ -75,8 +75,7 @@ impl<T: Data> Widget<T> for Link<T> {
             let is_active = self
                 .is_active
                 .as_ref()
-                .map(|predicate| predicate(data, env))
-                .unwrap_or(false);
+                .map_or(false, |predicate| predicate(data, env));
             if is_active {
                 env.get(theme::LINK_ACTIVE_COLOR)
             } else {


### PR DESCRIPTION
While I was working on #548, I noticed a few areas where code was unnecessarily copied or did extra work/computation that it didn't need to do. Most of that was in the WebApi client struct, but there were a few other instances elsewhere as well. There were also some issues that clippy was complaining about which I took care of.

As far as I can tell, everything still works just as expected after these changes.