### PR TITLE
Add case for new CDN expiry format

### DIFF
--- a/psst-core/src/cdn.rs
+++ b/psst-core/src/cdn.rs
@@ -145,16 +145,22 @@ fn parse_total_content_length(response: &ureq::Response) -> u64 {
 ///  1. `exp` field after `__token__`:
 ///     .../...a35817ca410?__token__=exp=1629466995~hmac=df348...
 ///                                      ^========^
-///  2. or at the beginning of the first query parameter:
+///  2. `verify` parameter (spotifycdn.com):
+///     .../...a23b4?verify=1731523536-a5v83c3W...
+///                         ^========^
+///  3. or at the beginning of the first query parameter:
 ///     .../59db919e18d6336461a0c71da051842ceef1b5af?1602319025_wu-SPeHxn...
 ///                                                  ^========^
 fn parse_expiration(url: &str) -> Option<Duration> {
     let token_exp = url.split("__token__=exp=").nth(1);
     let expires_millis = if let Some(token_exp) = token_exp {
-        // Parse from the expiration token param.
+        // Parse from the expiration token param
         token_exp.split('~').next()?
+    } else if let Some(verify_exp) = url.split("verify=").nth(1) {
+        // Parse from verify parameter (new spotifycdn.com format)
+        verify_exp.split('-').next()?
     } else {
-        // Parse from the first param.
+        // Parse from the first param
         let first_param = url.split('?').nth(1)?;
         first_param.split('_').next()?
     };


### PR DESCRIPTION
Was seeing this error.
```
[2024-11-12T18:47:48Z WARN  psst_core::cdn] failed to parse expiration time from URL "https://audio-cf-del-574.spotifycdn.com/audio/4c1a1bc8b75c504c20a61d9dbad9eb4702916c42?verify=1731523668-nR9%2FUYjaLrUCcKqdKKFsJumymC9MlI0V68g2lvahvPY%3D"
```
Not sure if this is all new connections now, if so we can remove the old cases as well.