### PR TITLE
Fix `open.spotify.com` playlist URLs not working in search bar

### DIFF
--- a/psst-gui/src/webapi/client.rs
+++ b/psst-gui/src/webapi/client.rs
@@ -1218,7 +1218,7 @@ impl WebApi {
 
     // https://developer.spotify.com/documentation/web-api/reference/get-playlist
     pub fn get_playlist(&self, id: &str) -> Result<Playlist, Error> {
-        let request = self.get(format!("v1/me/playlists/{}", id), None)?;
+        let request = self.get(format!("v1/playlists/{}", id), None)?;
         let result = self.load(request)?;
         Ok(result)
     }


### PR DESCRIPTION
It seems like a typo is in the code or a previously working endpoint has been disabled by Spotify. Either way, the fix is trivial given that the parent method is only referenced in one place, that being the search bar logic.

Closes #565 