### PR TITLE
Sanitize all playlist descriptions

### DIFF
--- a/psst-gui/src/data/playlist.rs
+++ b/psst-gui/src/data/playlist.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
 use druid::{im::Vector, Data, Lens};
-use serde::{Deserialize, Deserializer, Serialize};
 use sanitize_html::rules::predefined::DEFAULT;
 use sanitize_html::sanitize_str;
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::data::{user::PublicUser, Image, Promise, Track, TrackId};
 
@@ -31,7 +31,7 @@ pub struct Playlist {
     pub name: Arc<str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub images: Option<Vector<Image>>,
-    #[serde(deserialize_with = "deserialize_sanitized_description")]
+    #[serde(deserialize_with = "deserialize_description")]
     pub description: Arc<str>,
     #[serde(rename = "tracks")]
     #[serde(deserialize_with = "deserialize_track_count")]
@@ -93,7 +93,7 @@ where
     Ok(PlaylistTracksRef::deserialize(deserializer)?.total)
 }
 
-fn deserialize_sanitized_description<'de, D>(deserializer: D) -> Result<Arc<str>, D::Error>
+fn deserialize_description<'de, D>(deserializer: D) -> Result<Arc<str>, D::Error>
 where
     D: Deserializer<'de>,
 {

--- a/psst-gui/src/webapi/client.rs
+++ b/psst-gui/src/webapi/client.rs
@@ -1204,15 +1204,6 @@ impl WebApi {
     pub fn get_playlists(&self) -> Result<Vector<Playlist>, Error> {
         let request = self.get("v1/me/playlists", None)?;
         let result: Vector<Playlist> = self.load_all_pages(request)?;
-
-        let result = result
-            .into_iter()
-            .map(|mut playlist| {
-                playlist.description = Self::sanitize_html(&playlist.description).into();
-                playlist
-            })
-            .collect();
-
         Ok(result)
     }
 
@@ -1231,8 +1222,7 @@ impl WebApi {
     // https://developer.spotify.com/documentation/web-api/reference/get-playlist
     pub fn get_playlist(&self, id: &str) -> Result<Playlist, Error> {
         let request = self.get(format!("v1/playlists/{}", id), None)?;
-        let mut result: Playlist = self.load(request)?;
-        result.description = Self::sanitize_html(&result.description).into();
+        let result: Playlist = self.load(request)?;
         Ok(result)
     }
 

--- a/psst-gui/src/webapi/client.rs
+++ b/psst-gui/src/webapi/client.rs
@@ -485,7 +485,7 @@ impl WebApi {
                                     },
                                 )),
                                 description: {
-                                    let desc = Self::sanitize_and_clean_description(
+                                    let desc = Self::sanitize_html(
                                         item.content
                                             .data
                                             .description
@@ -622,9 +622,8 @@ impl WebApi {
         })
     }
 
-    fn sanitize_and_clean_description(description: &str) -> String {
+    fn sanitize_html(description: &str) -> String {
         let sanitized = sanitize_str(&DEFAULT, description).unwrap_or_default();
-        // Replace HTML entities with their actual characters
         sanitized.replace("&amp;", "&")
     }
 }
@@ -1209,8 +1208,7 @@ impl WebApi {
         let result = result
             .into_iter()
             .map(|mut playlist| {
-                playlist.description =
-                    Self::sanitize_and_clean_description(&playlist.description).into();
+                playlist.description = Self::sanitize_html(&playlist.description).into();
                 playlist
             })
             .collect();
@@ -1234,7 +1232,7 @@ impl WebApi {
     pub fn get_playlist(&self, id: &str) -> Result<Playlist, Error> {
         let request = self.get(format!("v1/playlists/{}", id), None)?;
         let mut result: Playlist = self.load(request)?;
-        result.description = Self::sanitize_and_clean_description(&result.description).into();
+        result.description = Self::sanitize_html(&result.description).into();
         Ok(result)
     }
 
@@ -1337,8 +1335,7 @@ impl WebApi {
             page.items
                 .into_iter()
                 .map(|mut playlist| {
-                    playlist.description =
-                        Self::sanitize_and_clean_description(&playlist.description).into();
+                    playlist.description = Self::sanitize_html(&playlist.description).into();
                     playlist
                 })
                 .collect()


### PR DESCRIPTION
This should in theory cover all descriptions from playlists and sanitize them appropriately. There were still issues with some descriptions that were in the search results, and ampersands were not properly replaced with their actual character.