### PR TITLE
Highlight track in nav context from link & fix link resolution loop

### DIFF
--- a/psst-gui/src/controller/nav.rs
+++ b/psst-gui/src/controller/nav.rs
@@ -34,7 +34,7 @@ impl NavController {
                     ctx.submit_command(search::LOAD_RESULTS.with(query.to_owned()));
                 }
             }
-            Nav::AlbumDetail(link) => {
+            Nav::AlbumDetail(link, _) => {
                 if !data.album_detail.album.contains(link) {
                     ctx.submit_command(album::LOAD_DETAIL.with(link.to_owned()));
                 }

--- a/psst-gui/src/data/mod.rs
+++ b/psst-gui/src/data/mod.rs
@@ -179,12 +179,11 @@ impl AppState {
 
 impl AppState {
     pub fn navigate(&mut self, nav: &Nav) {
-        if &self.nav != nav {
-            let previous: Nav = mem::replace(&mut self.nav, nav.to_owned());
-            self.history.push_back(previous);
-            self.config.last_route.replace(nav.to_owned());
-
-            Arc::make_mut(&mut self.common_ctx).nav = nav.to_owned();
+        if nav != &self.nav {
+            self.history.push_back(self.nav.clone());
+            self.config.last_route.replace(nav.clone());
+            self.nav = nav.clone();
+            Arc::make_mut(&mut self.common_ctx).nav = nav.clone();
         }
     }
 

--- a/psst-gui/src/data/nav.rs
+++ b/psst-gui/src/data/nav.rs
@@ -4,6 +4,7 @@ use druid::Data;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
+use crate::data::track::TrackId;
 use crate::data::{AlbumLink, ArtistLink, PlaylistLink, ShowLink};
 
 use super::RecommendationsRequest;
@@ -23,7 +24,7 @@ pub enum Route {
     Recommendations,
 }
 
-#[derive(Default, Clone, Debug, Data, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Data, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum Nav {
     #[default]
     Home,
@@ -32,10 +33,10 @@ pub enum Nav {
     SavedAlbums,
     SavedShows,
     SearchResults(Arc<str>),
+    AlbumDetail(AlbumLink, Option<TrackId>),
     ArtistDetail(ArtistLink),
-    AlbumDetail(AlbumLink),
-    ShowDetail(ShowLink),
     PlaylistDetail(PlaylistLink),
+    ShowDetail(ShowLink),
     Recommendations(Arc<RecommendationsRequest>),
 }
 
@@ -48,8 +49,8 @@ impl Nav {
             Nav::SavedAlbums => Route::SavedAlbums,
             Nav::SavedShows => Route::SavedShows,
             Nav::SearchResults(_) => Route::SearchResults,
+            Nav::AlbumDetail(_, _) => Route::AlbumDetail,
             Nav::ArtistDetail(_) => Route::ArtistDetail,
-            Nav::AlbumDetail(_) => Route::AlbumDetail,
             Nav::PlaylistDetail(_) => Route::PlaylistDetail,
             Nav::ShowDetail(_) => Route::ShowDetail,
             Nav::Recommendations(_) => Route::Recommendations,
@@ -64,7 +65,7 @@ impl Nav {
             Nav::SavedAlbums => "Saved Albums".to_string(),
             Nav::SavedShows => "Saved Podcasts".to_string(),
             Nav::SearchResults(query) => query.to_string(),
-            Nav::AlbumDetail(link) => link.name.to_string(),
+            Nav::AlbumDetail(link, _) => link.name.to_string(),
             Nav::ArtistDetail(link) => link.name.to_string(),
             Nav::PlaylistDetail(link) => link.name.to_string(),
             Nav::ShowDetail(link) => link.name.to_string(),
@@ -79,11 +80,11 @@ impl Nav {
             Nav::SavedTracks => "Saved Tracks".to_string(),
             Nav::SavedAlbums => "Saved Albums".to_string(),
             Nav::SavedShows => "Saved Shows".to_string(),
-            Nav::SearchResults(query) => format!("Search “{}”", query),
-            Nav::AlbumDetail(link) => format!("Album “{}”", link.name),
-            Nav::ArtistDetail(link) => format!("Artist “{}”", link.name),
-            Nav::PlaylistDetail(link) => format!("Playlist “{}”", link.name),
-            Nav::ShowDetail(link) => format!("Show “{}”", link.name),
+            Nav::SearchResults(query) => format!("Search \"{}\"", query),
+            Nav::AlbumDetail(link, _) => format!("Album \"{}\"", link.name),
+            Nav::ArtistDetail(link) => format!("Artist \"{}\"", link.name),
+            Nav::PlaylistDetail(link) => format!("Playlist \"{}\"", link.name),
+            Nav::ShowDetail(link) => format!("Show \"{}\"", link.name),
             Nav::Recommendations(_) => "Recommended".to_string(),
         }
     }

--- a/psst-gui/src/data/nav.rs
+++ b/psst-gui/src/data/nav.rs
@@ -105,7 +105,6 @@ impl SpotifyUrl {
         let mut segments = url.path_segments()?;
         let entity = segments.next()?;
         let id = segments.next()?;
-        log::info!("url: {:?}", url);
         match entity {
             "playlist" => Some(Self::Playlist(id.into())),
             "artist" => Some(Self::Artist(id.into())),

--- a/psst-gui/src/data/playback.rs
+++ b/psst-gui/src/data/playback.rs
@@ -122,7 +122,7 @@ impl PlaybackOrigin {
         match &self {
             PlaybackOrigin::Home => Nav::Home,
             PlaybackOrigin::Library => Nav::SavedTracks,
-            PlaybackOrigin::Album(link) => Nav::AlbumDetail(link.clone()),
+            PlaybackOrigin::Album(link) => Nav::AlbumDetail(link.clone(), None),
             PlaybackOrigin::Artist(link) => Nav::ArtistDetail(link.clone()),
             PlaybackOrigin::Playlist(link) => Nav::PlaylistDetail(link.clone()),
             PlaybackOrigin::Show(link) => Nav::ShowDetail(link.clone()),

--- a/psst-gui/src/ui/album.rs
+++ b/psst-gui/src/ui/album.rs
@@ -178,7 +178,7 @@ pub fn album_widget(horizontal: bool) -> impl Widget<WithCtx<Arc<Album>>> {
         .link()
         .rounded(theme::BUTTON_BORDER_RADIUS)
         .on_left_click(|ctx, _, album, _| {
-            ctx.submit_command(cmd::NAVIGATE.with(Nav::AlbumDetail(album.data.link())));
+            ctx.submit_command(cmd::NAVIGATE.with(Nav::AlbumDetail(album.data.link(), None)));
         })
         .context_menu(album_ctx_menu)
 }

--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -555,7 +555,7 @@ fn route_icon_widget() -> impl Widget<Nav> {
                     Empty.boxed()
                 }
                 Nav::SearchResults(_) | Nav::Recommendations(_) => icon(&icons::SEARCH).boxed(),
-                Nav::AlbumDetail(_) => icon(&icons::ALBUM).boxed(),
+                Nav::AlbumDetail(_, _) => icon(&icons::ALBUM).boxed(),
                 Nav::ArtistDetail(_) => icon(&icons::ARTIST).boxed(),
                 Nav::PlaylistDetail(_) => icon(&icons::PLAYLIST).boxed(),
                 Nav::ShowDetail(_) => icon(&icons::PODCAST).boxed(),

--- a/psst-gui/src/ui/track.rs
+++ b/psst-gui/src/ui/track.rs
@@ -178,20 +178,18 @@ pub fn playable_widget(track: &Track, display: Display) -> impl Widget<PlayRow<A
         .with_child(saved)
         .padding(theme::grid(1.0))
         .link()
-        .active(|row: &PlayRow<Arc<Track>>, _env: &Env| {
-            match &row.ctx.nav {
-                Nav::AlbumDetail(_, Some(target_id)) => *target_id == row.item.id,
-                _ => {
-                    if row.is_playing {
-                        true
-                    } else if let Some(playable) = &row.ctx.now_playing {
-                        match playable {
-                            Playable::Track(track) => track.id == row.item.id,
-                            _ => false,
-                        }
-                    } else {
-                        false
+        .active(|row: &PlayRow<Arc<Track>>, _env: &Env| match &row.ctx.nav {
+            Nav::AlbumDetail(_, Some(target_id)) => *target_id == row.item.id,
+            _ => {
+                if row.is_playing {
+                    true
+                } else if let Some(playable) = &row.ctx.now_playing {
+                    match playable {
+                        Playable::Track(track) => track.id == row.item.id,
+                        _ => false,
                     }
+                } else {
+                    false
                 }
             }
         })

--- a/psst-gui/src/ui/track.rs
+++ b/psst-gui/src/ui/track.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use druid::{
     widget::{CrossAxisAlignment, Either, Flex, Label, ViewSwitcher},
-    LensExt, LocalizedString, Menu, MenuItem, Size, TextAlignment, Widget, WidgetExt,
+    Env, LensExt, LocalizedString, Menu, MenuItem, Size, TextAlignment, Widget, WidgetExt,
 };
 use psst_core::{
     audio::normalize::NormalizationLevel,
@@ -13,8 +13,8 @@ use psst_core::{
 use crate::{
     cmd,
     data::{
-        AppState, Library, Nav, PlaybackOrigin, PlaylistAddTrack, PlaylistRemoveTrack, QueueEntry,
-        RecommendationsRequest, Track,
+        AppState, Library, Nav, Playable, PlaybackOrigin, PlaylistAddTrack, PlaylistRemoveTrack,
+        QueueEntry, RecommendationsRequest, Track,
     },
     ui::playlist,
     widget::{icons, Empty, MyWidgetExt, RemoteImage},
@@ -178,7 +178,23 @@ pub fn playable_widget(track: &Track, display: Display) -> impl Widget<PlayRow<A
         .with_child(saved)
         .padding(theme::grid(1.0))
         .link()
-        .active(|row, _| row.is_playing)
+        .active(|row: &PlayRow<Arc<Track>>, _env: &Env| {
+            match &row.ctx.nav {
+                Nav::AlbumDetail(_, Some(target_id)) => *target_id == row.item.id,
+                _ => {
+                    if row.is_playing {
+                        true
+                    } else if let Some(playable) = &row.ctx.now_playing {
+                        match playable {
+                            Playable::Track(track) => track.id == row.item.id,
+                            _ => false,
+                        }
+                    } else {
+                        false
+                    }
+                }
+            }
+        })
         .rounded(theme::BUTTON_BORDER_RADIUS)
         .context_menu(track_row_menu)
 }
@@ -245,7 +261,7 @@ pub fn track_menu(
             MenuItem::new(
                 LocalizedString::new("menu-item-show-album").with_placeholder("Go to Album"),
             )
-            .command(cmd::NAVIGATE.with(Nav::AlbumDetail(album_link.to_owned()))),
+            .command(cmd::NAVIGATE.with(Nav::AlbumDetail(album_link.to_owned(), None))),
         );
     }
 

--- a/psst-gui/src/ui/track.rs
+++ b/psst-gui/src/ui/track.rs
@@ -178,20 +178,15 @@ pub fn playable_widget(track: &Track, display: Display) -> impl Widget<PlayRow<A
         .with_child(saved)
         .padding(theme::grid(1.0))
         .link()
-        .active(|row: &PlayRow<Arc<Track>>, _env: &Env| match &row.ctx.nav {
-            Nav::AlbumDetail(_, Some(target_id)) => *target_id == row.item.id,
-            _ => {
-                if row.is_playing {
-                    true
-                } else if let Some(playable) = &row.ctx.now_playing {
-                    match playable {
-                        Playable::Track(track) => track.id == row.item.id,
-                        _ => false,
-                    }
-                } else {
-                    false
-                }
+        .active(|row: &PlayRow<Arc<Track>>, _env: &Env| {
+            // Check if this track is the target of album detail navigation
+            if let Nav::AlbumDetail(_, Some(target_id)) = &row.ctx.nav {
+                return *target_id == row.item.id;
             }
+            // Otherwise check if it's playing or is the current track
+            row.is_playing || row.ctx.now_playing.as_ref().map_or(false, |playable| {
+                matches!(playable, Playable::Track(track) if track.id == row.item.id)
+            })
         })
         .rounded(theme::BUTTON_BORDER_RADIUS)
         .context_menu(track_row_menu)

--- a/psst-gui/src/webapi/client.rs
+++ b/psst-gui/src/webapi/client.rs
@@ -1335,7 +1335,7 @@ impl WebApi {
             SpotifyUrl::Playlist(id) => Nav::PlaylistDetail(self.get_playlist(id)?.link()),
             SpotifyUrl::Artist(id) => Nav::ArtistDetail(self.get_artist(id)?.link()),
             SpotifyUrl::Album(id) => Nav::AlbumDetail(self.get_album(id)?.data.link(), None),
-            SpotifyUrl::Show(id) => Nav::ShowDetail(self.get_show_detail(id)?.link()),
+            SpotifyUrl::Show(id) => Nav::AlbumDetail(self.get_album(id)?.data.link(), None),
             SpotifyUrl::Track(id) => {
                 let track = self.get_track(id)?;
                 let album = track.album.clone().ok_or_else(|| {
@@ -1345,11 +1345,6 @@ impl WebApi {
             }
         };
         Ok(nav)
-    }
-
-    pub fn get_show_detail(&self, id: &str) -> Result<Arc<Show>, Error> {
-        let request = self.get(format!("v1/shows/{}", id), None)?;
-        self.load(request)
     }
 }
 

--- a/psst-gui/src/webapi/client.rs
+++ b/psst-gui/src/webapi/client.rs
@@ -128,8 +128,7 @@ impl WebApi {
     /// Send a request with a empty JSON object, throw away the response body.
     /// Use for POST/PUT/DELETE requests.
     fn send_empty_json(&self, request: Request) -> Result<(), Error> {
-        Self::with_retry(|| Ok(request.clone().send_string("{}")?))
-            .map(|_| ())
+        Self::with_retry(|| Ok(request.clone().send_string("{}")?)).map(|_| ())
     }
 
     /// Send a request and return the deserialized JSON body.  Use for GET
@@ -513,13 +512,14 @@ impl WebApi {
                                 ),
                                 owner: PublicUser {
                                     id: Arc::from(""),
-                                    display_name: Arc::from(item
-                                        .content
-                                        .data
-                                        .owner_v2
-                                        .as_ref()
-                                        .map(|owner| owner.data.name.as_str())
-                                        .unwrap_or_default())
+                                    display_name: Arc::from(
+                                        item.content
+                                            .data
+                                            .owner_v2
+                                            .as_ref()
+                                            .map(|owner| owner.data.name.as_str())
+                                            .unwrap_or_default(),
+                                    ),
                                 },
                                 collaborative: false,
                             });
@@ -1334,16 +1334,22 @@ impl WebApi {
         let nav = match link {
             SpotifyUrl::Playlist(id) => Nav::PlaylistDetail(self.get_playlist(id)?.link()),
             SpotifyUrl::Artist(id) => Nav::ArtistDetail(self.get_artist(id)?.link()),
-            SpotifyUrl::Album(id) => Nav::AlbumDetail(self.get_album(id)?.data.link()),
-            SpotifyUrl::Show(id) => Nav::AlbumDetail(self.get_album(id)?.data.link()),
-            SpotifyUrl::Track(id) => Nav::AlbumDetail(
-                // TODO: We should highlight the exact track in the album.
-                self.get_track(id)?.album.clone().ok_or_else(|| {
+            SpotifyUrl::Album(id) => Nav::AlbumDetail(self.get_album(id)?.data.link(), None),
+            SpotifyUrl::Show(id) => Nav::ShowDetail(self.get_show_detail(id)?.link()),
+            SpotifyUrl::Track(id) => {
+                let track = self.get_track(id)?;
+                let album = track.album.clone().ok_or_else(|| {
                     Error::WebApiError("Track was found but has no album".to_string())
-                })?,
-            ),
+                })?;
+                Nav::AlbumDetail(album, Some(track.id))
+            }
         };
         Ok(nav)
+    }
+
+    pub fn get_show_detail(&self, id: &str) -> Result<Arc<Show>, Error> {
+        let request = self.get(format!("v1/shows/{}", id), None)?;
+        self.load(request)
     }
 }
 


### PR DESCRIPTION
This was listed as a to-do item and often bothered me when I wanted to quickly open a Spotify link that someone had sent me. This is probably a more critical feature than I realized it to be.

This PR also fixes the issue where in navigating to a URL determined context, pressing back to navigate backwards would end up leading to resolving the URL once more, putting you in a loop you couldn't get out of.