### PR TITLE
Properly update version of Debian package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,6 +157,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Get full history to count number of commits for package version
 
       - name: Download Linux Binaries
         uses: actions/download-artifact@v4
@@ -190,14 +192,13 @@ jobs:
       - name: Move License
         run: mkdir -p ${{runner.workspace}}/pkg/usr/share/doc/psst-gui/; mv .pkg/copyright $_
 
-      - name: Move Package Config
+      - name: Write Package Config
         run: |
-          mkdir -p ${{runner.workspace}}/pkg/
-          cp -r .pkg/DEBIAN $_/
-          sed -i 's/Architecture: amd64/Architecture: ${{ matrix.arch }}/' ${{runner.workspace}}/pkg/DEBIAN/control
-
-      - name: Set Version
-        run: "echo Version: $(git rev-list --count HEAD) >> ${{runner.workspace}}/pkg/DEBIAN/control"
+          mkdir -p ${{runner.workspace}}/pkg/DEBIAN
+          export ARCHITECTURE=${{ matrix.arch }}
+          SANITIZED_BRANCH="$(echo ${GITHUB_HEAD_REF:+.$GITHUB_HEAD_REF}|tr '_/' '-')"
+          export VERSION=0.1.0"$SANITIZED_BRANCH"+r"$(git rev-list --count HEAD)"-0
+          envsubst < .pkg/DEBIAN/control > ${{runner.workspace}}/pkg/DEBIAN/control
 
       - name: Build Package
         run: |

--- a/.pkg/DEBIAN/control
+++ b/.pkg/DEBIAN/control
@@ -1,6 +1,6 @@
 Package: psst-gui
-Version: 0.1.0
-Architecture: amd64
+Version: $VERSION
+Architecture: $ARCHITECTURE
 Maintainer: Jan Pochyla <jpochyla@gmail.com>
 Section: sound
 Priority: optional


### PR DESCRIPTION
Include branch name in Debian package version

Sanitize branch name by Debian version policy:
https://www.debian.org/doc/debian-policy/ch-controlfields.html#version

---

This scratches my itch. Before this change all Debian packages were built with version 0.1.0. That prevented simple upgrades from package manager, as it refused to replace existing installation with the same version.

With this change packages built from main branch will have version like `0.1.0+r571-0`