### PR TITLE
UI: Enhance volume slider behavior

### DIFF
--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -455,7 +455,8 @@ fn volume_slider() -> impl Widget<AppState> {
         .with_child(
             Label::dynamic(|&volume: &f64, _| format!("{}%", (volume * 100.0).floor()))
                 .with_text_color(theme::PLACEHOLDER_COLOR)
-                .with_text_size(theme::TEXT_SIZE_SMALL),
+                .with_text_size(theme::TEXT_SIZE_SMALL)
+                .fix_width(theme::grid(4.0)),
         )
         .padding((theme::grid(2.0), 0.0))
         .on_debounce(SAVE_DELAY, |ctx, _, _| ctx.submit_command(SAVE_TO_CONFIG))


### PR DESCRIPTION
This small PR aims to fix the inconsistent slider size, which is currently affected by the text size of the percentage indicator. The variation occurs due to text kerning and changes in width when the number reaches 100, which determines the slider knob to snap from under the cursor.

- Current implementation
![broken](https://github.com/user-attachments/assets/a1bc5bc2-2258-464c-ab82-aa4598406f9e)

- This implementation
![working](https://github.com/user-attachments/assets/8476aa2e-b939-4f04-8a31-46c36714e692)


