### PR TITLE
Fix for window size save overwriting config on close

### DIFF
--- a/psst-gui/src/delegate.rs
+++ b/psst-gui/src/delegate.rs
@@ -190,11 +190,9 @@ impl AppDelegate<AppState> for Delegate {
             ctx.submit_command(RENAME_PLAYLIST.with(link.clone()));
             Handled::Yes
         } else if cmd.is(cmd::QUIT_APP_WITH_SAVE) {
-            data.config.save();
             ctx.submit_command(commands::QUIT_APP);
             Handled::Yes
         } else if cmd.is(commands::QUIT_APP) {
-            data.config.save();
             Handled::No
         } else if cmd.is(crate::cmd::SHOW_ARTWORK) {
             self.show_artwork(ctx);

--- a/psst-gui/src/main.rs
+++ b/psst-gui/src/main.rs
@@ -66,5 +66,4 @@ fn main() {
         .launch(state)
         .expect("Application launch");
 
-    config.save();
 }


### PR DESCRIPTION
There was a bug here with the way the config was being written. We don't need to write any config unless we close down nicely and we will save the window size if we can. Otherwise don't do it.

Resolves https://github.com/jpochyla/psst/issues/598