### PR TITLE
Clean up & hash the brew release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   VERSION_DATE: ${{ format('{0}.{1}.{2}', github.run_number, github.run_id, github.run_attempt) }}
@@ -304,6 +307,14 @@ jobs:
           echo "VERSION=0.1.0,$(date +'%Y%m%d.%H%M%S')" >> $GITHUB_ENV
           SHORT_SHA=${FULL_SHA::7}
           echo "RELEASE_VERSION=$(date +'%Y.%m.%d')-$SHORT_SHA" >> $GITHUB_ENV
+          echo "RELEASE_FILES=artifacts/Psst.dmg/Psst.dmg
+          artifacts/Psst.dmg.sha256/Psst.dmg.sha256
+          artifacts/Psst.exe/psst-gui.exe
+          artifacts/psst-x86_64-unknown-linux-gnu/psst
+          artifacts/psst-aarch64-unknown-linux-gnu/psst
+          artifacts/checksums.txt
+          artifacts/psst-deb-amd64/*.deb
+          artifacts/psst-deb-arm64/*.deb" >> $GITHUB_ENV
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -326,25 +337,35 @@ jobs:
           tag_name: v${{ env.RELEASE_VERSION }}
           body: |
             ## Psst ${{ env.RELEASE_VERSION }}
-            - Built on: $(date)
-            - Version: ${{ env.VERSION }}
+            Built: $(date)
+            Version: ${{ env.VERSION }}
 
-            ### SHA256 Checksums
+            **SHA256 Checksums:**
             ```
             $(cat artifacts/checksums.txt)
             ```
 
-            ### Homebrew Installation
+            **Homebrew:**
+            `brew install --cask psst`
+          files: ${{ env.RELEASE_FILES }}
+          generate_release_notes: false
+
+      - name: Create or Update Latest Build Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Psst Latest Build (main branch)
+          tag_name: latest # Fixed tag for the latest build
+          body: |
+            ## Psst Latest Build (main)
+            Commit: ${{ github.sha }}
+            Built: $(date)
+            Workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            Auto-updated from the main branch. For stable releases, see other tags.
+
+            **SHA256 Checksums:**
             ```
-            brew install --cask psst
+            $(cat artifacts/checksums.txt)
             ```
-          files: |
-            artifacts/Psst.dmg/Psst.dmg
-            artifacts/Psst.dmg.sha256/Psst.dmg.sha256
-            artifacts/Psst.exe/psst-gui.exe
-            artifacts/psst-x86_64-unknown-linux-gnu/psst
-            artifacts/psst-aarch64-unknown-linux-gnu/psst
-            artifacts/checksums.txt
-            artifacts/psst-deb-amd64/*.deb
-            artifacts/psst-deb-arm64/*.deb
+          files: ${{ env.RELEASE_FILES }}
           generate_release_notes: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,12 +156,16 @@ jobs:
         if: runner.os == 'Linux'
         run: chmod +x target/${{ matrix.target }}/release/psst-gui
 
+      - name: Rename Linux Binary
+        if: runner.os == 'Linux'
+        run: mv target/${{ matrix.target }}/release/psst-gui target/${{ matrix.target }}/release/psst
+
       - name: Upload Linux Binary
         uses: actions/upload-artifact@v4
         if: runner.os == 'Linux'
         with:
-          name: psst-gui-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/psst-gui
+          name: psst-${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/psst
 
       - name: Upload Windows Executable
         uses: actions/upload-artifact@v4
@@ -189,13 +193,13 @@ jobs:
       - name: Download Linux Binaries
         uses: actions/download-artifact@v4
         with:
-          name: psst-gui-${{ matrix.target }}
+          name: psst-${{ matrix.target }}
           path: binaries
 
       - name: Move Binary
         run: |
           mkdir -p pkg/usr/bin/
-          mv binaries/psst-gui pkg/usr/bin/
+          mv binaries/psst pkg/usr/bin/
 
       - name: Move Desktop Entry
         run: mkdir -p pkg/usr/share/applications/; mv .pkg/psst.desktop pkg/usr/share/applications/
@@ -213,7 +217,7 @@ jobs:
           cp "./psst-gui/assets/logo.svg" "pkg/usr/share/icons/hicolor/scalable/apps/psst.svg"
 
       - name: Set Permissions
-        run: chmod 755 pkg/usr/bin/psst-gui
+        run: chmod 755 pkg/usr/bin/psst
 
       - name: Move License
         run: mkdir -p pkg/usr/share/doc/psst-gui/; mv .pkg/copyright pkg/usr/share/doc/psst-gui/
@@ -294,7 +298,7 @@ jobs:
     steps:
       - name: Set Version Info
         env:
-          FULL_SHA: ${{ github.sha }
+          FULL_SHA: ${{ github.sha }}
         run: |
           echo "BUILD_DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
           echo "VERSION=0.1.0,$(date +'%Y%m%d.%H%M%S')" >> $GITHUB_ENV
@@ -309,8 +313,10 @@ jobs:
       - name: Generate SHA256 checksums
         run: |
           cd artifacts
-          find . -type f -name "*.dmg" -o -name "*.exe" -o -name "psst-gui-*" | while read file; do
-            sha256sum "$file" >> checksums.txt
+          find . -type f -name "*.dmg" -o -name "*.exe" -o -name "psst-*" | while read file; do
+            if [[ "$file" != *.sha256 ]]; then
+              sha256sum "$file" >> checksums.txt
+            fi
           done
 
       - name: Create Release
@@ -336,8 +342,8 @@ jobs:
             artifacts/Psst.dmg/Psst.dmg
             artifacts/Psst.dmg.sha256/Psst.dmg.sha256
             artifacts/Psst.exe/psst-gui.exe
-            artifacts/psst-gui-x86_64-unknown-linux-gnu/psst-gui
-            artifacts/psst-gui-aarch64-unknown-linux-gnu/psst-gui
+            artifacts/psst-x86_64-unknown-linux-gnu/psst
+            artifacts/psst-aarch64-unknown-linux-gnu/psst
             artifacts/checksums.txt
             artifacts/psst-deb-amd64/*.deb
             artifacts/psst-deb-arm64/*.deb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,15 +46,16 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Set Version Info
         id: version
+        shell: bash
+        env:
+          FULL_SHA: ${{ github.sha }}
         run: |
           echo "BUILD_DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
           echo "VERSION=0.1.0,$(date +'%Y%m%d.%H%M%S')" >> $GITHUB_ENV
-          SHORT_SHA=$(git rev-parse --short HEAD)
+          SHORT_SHA=${FULL_SHA::7}
           echo "RELEASE_VERSION=$(date +'%Y.%m.%d')-$SHORT_SHA" >> $GITHUB_ENV
 
       - name: Setup Rust Cache
@@ -291,16 +292,13 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Set Version Info
+        env:
+          FULL_SHA: ${{ github.sha }
         run: |
           echo "BUILD_DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
           echo "VERSION=0.1.0,$(date +'%Y%m%d.%H%M%S')" >> $GITHUB_ENV
-          SHORT_SHA=$(git rev-parse --short HEAD)
+          SHORT_SHA=${FULL_SHA::7}
           echo "RELEASE_VERSION=$(date +'%Y.%m.%d')-$SHORT_SHA" >> $GITHUB_ENV
 
       - name: Download all artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  VERSION_DATE: ${{ format('{0}.{1}.{2}', github.run_number, github.run_id, github.run_attempt) }}
+  VERSION_TIMESTAMP: ${{ github.event.repository.updated_at }}
 
 jobs:
   code-style:
@@ -44,6 +46,13 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+
+      - name: Set Version Info
+        id: version
+        run: |
+          echo "BUILD_DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+          echo "VERSION=0.1.0,$(date +'%Y%m%d.%H%M%S')" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=$(date +'%Y.%m.%d')" >> $GITHUB_OUTPUT
 
       - name: Setup Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -115,16 +124,29 @@ jobs:
             --hide-extension "Psst.app" \
             --app-drop-link 450 160 \
             --no-internet-enable \
-            "Psst.dmg" \
+            "Psst-${{ env.RELEASE_VERSION }}.dmg" \
             "target/release/bundle/osx/Psst.app"
+        working-directory: psst-gui
+
+      - name: Generate DMG Checksum
+        if: runner.os == 'macOS'
+        run: |
+          shasum -a 256 "Psst-${{ env.RELEASE_VERSION }}.dmg" > "Psst-${{ env.RELEASE_VERSION }}.dmg.sha256"
         working-directory: psst-gui
 
       - name: Upload macOS DMG
         uses: actions/upload-artifact@v4
         if: runner.os == 'macOS'
         with:
-          name: Psst.dmg
-          path: ./psst-gui/Psst.dmg
+          name: Psst-${{ env.RELEASE_VERSION }}.dmg
+          path: ./psst-gui/Psst-${{ env.RELEASE_VERSION }}.dmg
+
+      - name: Upload macOS DMG Checksum
+        uses: actions/upload-artifact@v4
+        if: runner.os == 'macOS'
+        with:
+          name: Psst-${{ env.RELEASE_VERSION }}.dmg.sha256
+          path: ./psst-gui/Psst-${{ env.RELEASE_VERSION }}.dmg.sha256
 
       - name: Make Linux Binary Executable
         if: runner.os == 'Linux'
@@ -257,3 +279,58 @@ jobs:
         with:
           name: psst-appimage
           path: ${{runner.workspace}}/out/*.AppImage
+
+  release:
+    needs: [build, deb]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Set Version Info
+        run: |
+          echo "BUILD_DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+          echo "VERSION=0.1.0,$(date +'%Y%m%d.%H%M%S')" >> $GITHUB_ENV 
+          echo "RELEASE_VERSION=$(date +'%Y.%m.%d')" >> $GITHUB_ENV
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Generate SHA256 checksums
+        run: |
+          cd artifacts
+          find . -type f -name "*.dmg" -o -name "*.exe" -o -name "psst-gui-*" | while read file; do
+            sha256sum "$file" >> checksums.txt
+          done
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Psst ${{ env.RELEASE_VERSION }}
+          tag_name: v${{ env.RELEASE_VERSION }}
+          body: |
+            ## Psst ${{ env.RELEASE_VERSION }}
+            - Built on: $(date)
+            - Version: ${{ env.VERSION }}
+
+            ### SHA256 Checksums
+            ```
+            $(cat artifacts/checksums.txt)
+            ```
+
+            ### Homebrew Installation
+            ```
+            brew install --cask psst
+            ```
+          files: |
+            artifacts/Psst-${{ env.RELEASE_VERSION }}.dmg/Psst-${{ env.RELEASE_VERSION }}.dmg
+            artifacts/Psst-${{ env.RELEASE_VERSION }}.dmg.sha256/Psst-${{ env.RELEASE_VERSION }}.dmg.sha256
+            artifacts/Psst.exe/psst-gui.exe
+            artifacts/psst-gui-x86_64-unknown-linux-gnu/psst-gui
+            artifacts/psst-gui-aarch64-unknown-linux-gnu/psst-gui
+            artifacts/checksums.txt
+            artifacts/psst-deb-amd64/*.deb
+            artifacts/psst-deb-arm64/*.deb
+          generate_release_notes: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,13 +46,16 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set Version Info
         id: version
         run: |
           echo "BUILD_DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
           echo "VERSION=0.1.0,$(date +'%Y%m%d.%H%M%S')" >> $GITHUB_ENV
-          echo "RELEASE_VERSION=$(date +'%Y.%m.%d')" >> $GITHUB_ENV
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          echo "RELEASE_VERSION=$(date +'%Y.%m.%d')-$SHORT_SHA" >> $GITHUB_ENV
 
       - name: Setup Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -124,29 +127,29 @@ jobs:
             --hide-extension "Psst.app" \
             --app-drop-link 450 160 \
             --no-internet-enable \
-            "Psst-${{ env.RELEASE_VERSION }}.dmg" \
+            "Psst.dmg" \
             "target/release/bundle/osx/Psst.app"
         working-directory: psst-gui
 
       - name: Generate DMG Checksum
         if: runner.os == 'macOS'
         run: |
-          shasum -a 256 "Psst-${{ env.RELEASE_VERSION }}.dmg" > "Psst-${{ env.RELEASE_VERSION }}.dmg.sha256"
+          shasum -a 256 "Psst.dmg" > "Psst.dmg.sha256"
         working-directory: psst-gui
 
       - name: Upload macOS DMG
         uses: actions/upload-artifact@v4
         if: runner.os == 'macOS'
         with:
-          name: Psst-${{ env.RELEASE_VERSION }}.dmg
-          path: ./psst-gui/Psst-${{ env.RELEASE_VERSION }}.dmg
+          name: Psst.dmg
+          path: ./psst-gui/Psst.dmg
 
       - name: Upload macOS DMG Checksum
         uses: actions/upload-artifact@v4
         if: runner.os == 'macOS'
         with:
-          name: Psst-${{ env.RELEASE_VERSION }}.dmg.sha256
-          path: ./psst-gui/Psst-${{ env.RELEASE_VERSION }}.dmg.sha256
+          name: Psst.dmg.sha256
+          path: ./psst-gui/Psst.dmg.sha256
 
       - name: Make Linux Binary Executable
         if: runner.os == 'Linux'
@@ -288,11 +291,17 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Set Version Info
         run: |
           echo "BUILD_DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
-          echo "VERSION=0.1.0,$(date +'%Y%m%d.%H%M%S')" >> $GITHUB_ENV 
-          echo "RELEASE_VERSION=$(date +'%Y.%m.%d')" >> $GITHUB_ENV
+          echo "VERSION=0.1.0,$(date +'%Y%m%d.%H%M%S')" >> $GITHUB_ENV
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          echo "RELEASE_VERSION=$(date +'%Y.%m.%d')-$SHORT_SHA" >> $GITHUB_ENV
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -326,8 +335,8 @@ jobs:
             brew install --cask psst
             ```
           files: |
-            artifacts/Psst-${{ env.RELEASE_VERSION }}.dmg/Psst-${{ env.RELEASE_VERSION }}.dmg
-            artifacts/Psst-${{ env.RELEASE_VERSION }}.dmg.sha256/Psst-${{ env.RELEASE_VERSION }}.dmg.sha256
+            artifacts/Psst.dmg/Psst.dmg
+            artifacts/Psst.dmg.sha256/Psst.dmg.sha256
             artifacts/Psst.exe/psst-gui.exe
             artifacts/psst-gui-x86_64-unknown-linux-gnu/psst-gui
             artifacts/psst-gui-aarch64-unknown-linux-gnu/psst-gui

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           echo "BUILD_DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
           echo "VERSION=0.1.0,$(date +'%Y%m%d.%H%M%S')" >> $GITHUB_ENV
-          echo "RELEASE_VERSION=$(date +'%Y.%m.%d')" >> $GITHUB_OUTPUT
+          echo "RELEASE_VERSION=$(date +'%Y.%m.%d')" >> $GITHUB_ENV
 
       - name: Setup Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -186,15 +186,15 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: psst-gui-${{ matrix.target }}
-          path: ${{runner.workspace}}/binaries
+          path: binaries
 
       - name: Move Binary
         run: |
-          mkdir -p ${{runner.workspace}}/pkg/usr/bin/
-          mv ${{runner.workspace}}/binaries/psst-gui ${{runner.workspace}}/pkg/usr/bin/
+          mkdir -p pkg/usr/bin/
+          mv binaries/psst-gui pkg/usr/bin/
 
       - name: Move Desktop Entry
-        run: mkdir -p ${{runner.workspace}}/pkg/usr/share/applications/; mv .pkg/psst.desktop $_
+        run: mkdir -p pkg/usr/share/applications/; mv .pkg/psst.desktop pkg/usr/share/applications/
 
       - name: Add Icons
         run: |
@@ -202,30 +202,30 @@ jobs:
           for LOGO in $LOGOS
           do
             LOGO_SIZE=$(echo "${LOGO}" | grep -oE '[[:digit:]]{2,}')
-            mkdir -p "${{runner.workspace}}/pkg/usr/share/icons/hicolor/${LOGO_SIZE}x${LOGO_SIZE}/"
-            cp "./psst-gui/assets/${LOGO}" "$_/psst.png"
+            mkdir -p "pkg/usr/share/icons/hicolor/${LOGO_SIZE}x${LOGO_SIZE}/"
+            cp "./psst-gui/assets/${LOGO}" "pkg/usr/share/icons/hicolor/${LOGO_SIZE}x${LOGO_SIZE}/psst.png"
           done
-          mkdir -p "${{runner.workspace}}/pkg/usr/share/icons/hicolor/scalable/apps/"
-          cp "./psst-gui/assets/logo.svg" "$_/psst.svg"
+          mkdir -p "pkg/usr/share/icons/hicolor/scalable/apps/"
+          cp "./psst-gui/assets/logo.svg" "pkg/usr/share/icons/hicolor/scalable/apps/psst.svg"
 
       - name: Set Permissions
-        run: chmod 755 ${{runner.workspace}}/pkg/usr/bin/psst-gui
+        run: chmod 755 pkg/usr/bin/psst-gui
 
       - name: Move License
-        run: mkdir -p ${{runner.workspace}}/pkg/usr/share/doc/psst-gui/; mv .pkg/copyright $_
+        run: mkdir -p pkg/usr/share/doc/psst-gui/; mv .pkg/copyright pkg/usr/share/doc/psst-gui/
 
       - name: Write Package Config
         run: |
-          mkdir -p ${{runner.workspace}}/pkg/DEBIAN
+          mkdir -p pkg/DEBIAN
           export ARCHITECTURE=${{ matrix.arch }}
           SANITIZED_BRANCH="$(echo ${GITHUB_HEAD_REF:+.$GITHUB_HEAD_REF}|tr '_/' '-')"
           export VERSION=0.1.0"$SANITIZED_BRANCH"+r"$(git rev-list --count HEAD)"-0
-          envsubst < .pkg/DEBIAN/control > ${{runner.workspace}}/pkg/DEBIAN/control
+          envsubst < .pkg/DEBIAN/control > pkg/DEBIAN/control
 
       - name: Build Package
         run: |
-          cat ${{runner.workspace}}/pkg/DEBIAN/control
-          dpkg-deb -b ${{runner.workspace}}/pkg/ psst_$(git rev-list --count HEAD)_${{ matrix.arch }}.deb
+          cat pkg/DEBIAN/control
+          dpkg-deb -b pkg/ psst_$(git rev-list --count HEAD)_${{ matrix.arch }}.deb
 
       - name: Upload Debian Package
         uses: actions/upload-artifact@v4
@@ -245,29 +245,30 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: psst-deb
-          path: ${{runner.workspace}}
+          # Downloads to the root of the workspace by default if path is omitted or '.',
+          # so removing explicit path to ${{github.workspace}}
 
       - name: Install Dependencies
         run: sudo apt-get update && sudo apt-get install -y libfuse2
 
       - name: Create Workspace
-        run: mkdir -p ${{runner.workspace}}/appimage
+        run: mkdir -p appimage
 
       - name: Download the Latest pkg2appimage
         run: |
           latest_release_appimage_url=$(wget -q https://api.github.com/repos/AppImageCommunity/pkg2appimage/releases/latest -O - | jq -r '.assets[0].browser_download_url')
-          wget --directory-prefix=${{runner.workspace}}/appimage -c $latest_release_appimage_url
+          wget --directory-prefix=appimage -c $latest_release_appimage_url
 
       - name: Create Path to pkg2appimage
         run: |
-          pkg2appimage_executable=$(ls ${{runner.workspace}}/appimage)
-          app_path=${{runner.workspace}}/appimage/${pkg2appimage_executable}
+          pkg2appimage_executable=$(ls appimage)
+          app_path=appimage/${pkg2appimage_executable}
           chmod +x ${app_path}
           echo "app_path=${app_path}" >> $GITHUB_ENV
 
       - name: Create Path to pkg2appimage's Recipe File
         run: |
-          recipe_path=${{runner.workspace}}/psst/.pkg/APPIMAGE/pkg2appimage-ingredients.yml
+          recipe_path=psst/.pkg/APPIMAGE/pkg2appimage-ingredients.yml
           echo "recipe_path=${recipe_path}" >> $GITHUB_ENV
 
       - name: Run pkg2appimage
@@ -278,7 +279,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: psst-appimage
-          path: ${{runner.workspace}}/out/*.AppImage
+          path: out/*.AppImage
 
   release:
     needs: [build, deb]

--- a/.homebrew/generate_formula.sh
+++ b/.homebrew/generate_formula.sh
@@ -1,38 +1,70 @@
 #!/bin/bash
-# Script to generate Homebrew formula information for Psst
 
-# Get latest release info
-VERSION=$(curl -s "https://api.github.com/repos/jpochyla/psst/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
-DOWNLOAD_URL="https://github.com/jpochyla/psst/releases/download/v${VERSION}/Psst.dmg"
-SHA256=$(curl -sL "https://github.com/jpochyla/psst/releases/download/v${VERSION}/Psst.dmg.sha256" | awk '{print $1}')
+set -eo pipefail
 
-echo "Psst Homebrew Formula Information"
-echo "================================="
-echo "Version: ${VERSION}"
-echo "Download URL: ${DOWNLOAD_URL}"
-echo "SHA256: ${SHA256}"
-echo
-echo "Homebrew Cask Formula:"
-echo "----------------------"
+REPO_OWNER="jpochyla"
+REPO_NAME="psst"
+
+LATEST_VERSION_TAG_NO_V=$(git ls-remote --tags "https://github.com/${REPO_OWNER}/${REPO_NAME}.git" | \
+    grep -Eo 'refs/tags/v[0-9]{4}\.[0-9]{2}\.[0-9]{2}-[a-f0-9]{7}$' | \
+    sed 's|refs/tags/v||' | sort -V | tail -n1)
+
+if [ -z "$LATEST_VERSION_TAG_NO_V" ]; then
+  echo "Error: No versioned tag found." >&2
+  exit 1
+fi
+
+VERSION="$LATEST_VERSION_TAG_NO_V"
+TAG_WITH_V="v${VERSION}"
+
+RELEASE_INFO_JSON=$(curl -sL "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/tags/${TAG_WITH_V}")
+
+DMG_URL=$(echo "$RELEASE_INFO_JSON" | jq -r '.assets[] | select(.name=="Psst.dmg") | .browser_download_url')
+CHECKSUMS_URL=$(echo "$RELEASE_INFO_JSON" | jq -r '.assets[] | select(.name=="checksums.txt") | .browser_download_url')
+
+if [ -z "$DMG_URL" ] || [ "$DMG_URL" == "null" ]; then
+  echo "Error: Could not find Psst.dmg asset URL for tag ${TAG_WITH_V}." >&2
+  exit 1
+fi
+if [ -z "$CHECKSUMS_URL" ] || [ "$CHECKSUMS_URL" == "null" ]; then
+  echo "Error: Could not find checksums.txt asset URL for tag ${TAG_WITH_V}." >&2
+  exit 1
+fi
+
+SHA256=$(curl -sL "$CHECKSUMS_URL" | grep '\./Psst.dmg/Psst.dmg$' | awk '{print $1}')
+
+if [ -z "$SHA256" ]; then
+  echo "Error: Could not find SHA256 for Psst.dmg in checksums.txt." >&2
+  exit 1
+fi
 
 cat <<EOF
 cask "psst" do
   version "${VERSION}"
   sha256 "${SHA256}"
 
-  url "https://github.com/jpochyla/psst/releases/download/v#{version}/Psst.dmg"
+  url "${DMG_URL}",
+      verified: "github.com/${REPO_OWNER}/${REPO_NAME}/"
   name "Psst"
-  desc "Fast and multi-platform Spotify client"
-  homepage "https://github.com/jpochyla/psst"
+  desc "Fast, native Spotify client"
+  homepage "https://github.com/${REPO_OWNER}/${REPO_NAME}/"
+
+  livecheck do
+    url "https://github.com/${REPO_OWNER}/${REPO_NAME}/releases"
+    strategy :github_latest
+    regex(/^v?(\d{4}\.\d{2}\.\d{2}-[0-9a-f]{7})$/i)
+  end
 
   app "Psst.app"
 
-  depends_on macos: ">= 11.0"
+  depends_on macos: ">= :big_sur"
 
   zap trash: [
     "~/Library/Application Support/com.jpochyla.psst",
     "~/Library/Caches/com.jpochyla.psst",
-    "~/Library/Preferences/com.jpochyla.psst.plist"
+    "~/Library/HTTPStorages/com.jpochyla.psst",
+    "~/Library/Preferences/com.jpochyla.psst.plist",
+    "~/Library/Saved Application State/com.jpochyla.psst.savedState",
   ]
 end
 EOF

--- a/.homebrew/generate_formula.sh
+++ b/.homebrew/generate_formula.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Script to generate Homebrew formula information for Psst
+
+# Get latest release info
+VERSION=$(curl -s "https://api.github.com/repos/jpochyla/psst/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
+DOWNLOAD_URL="https://github.com/jpochyla/psst/releases/download/v${VERSION}/Psst-${VERSION}.dmg"
+SHA256=$(curl -sL "https://github.com/jpochyla/psst/releases/download/v${VERSION}/Psst-${VERSION}.dmg.sha256" | awk '{print $1}')
+
+echo "Psst Homebrew Formula Information"
+echo "================================="
+echo "Version: ${VERSION}"
+echo "Download URL: ${DOWNLOAD_URL}"
+echo "SHA256: ${SHA256}"
+echo
+echo "Homebrew Cask Formula:"
+echo "----------------------"
+
+cat << EOF
+cask "psst" do
+  version "${VERSION}"
+  sha256 "${SHA256}"
+
+  url "https://github.com/jpochyla/psst/releases/download/v#{version}/Psst-#{version}.dmg"
+  name "Psst"
+  desc "Fast and multi-platform Spotify client"
+  homepage "https://github.com/jpochyla/psst"
+
+  app "Psst.app"
+
+  depends_on macos: ">= 11.0"
+
+  zap trash: [
+    "~/Library/Application Support/com.jpochyla.psst",
+    "~/Library/Caches/com.jpochyla.psst",
+    "~/Library/Preferences/com.jpochyla.psst.plist"
+  ]
+end
+EOF

--- a/.homebrew/generate_formula.sh
+++ b/.homebrew/generate_formula.sh
@@ -3,8 +3,8 @@
 
 # Get latest release info
 VERSION=$(curl -s "https://api.github.com/repos/jpochyla/psst/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
-DOWNLOAD_URL="https://github.com/jpochyla/psst/releases/download/v${VERSION}/Psst-${VERSION}.dmg"
-SHA256=$(curl -sL "https://github.com/jpochyla/psst/releases/download/v${VERSION}/Psst-${VERSION}.dmg.sha256" | awk '{print $1}')
+DOWNLOAD_URL="https://github.com/jpochyla/psst/releases/download/v${VERSION}/Psst.dmg"
+SHA256=$(curl -sL "https://github.com/jpochyla/psst/releases/download/v${VERSION}/Psst.dmg.sha256" | awk '{print $1}')
 
 echo "Psst Homebrew Formula Information"
 echo "================================="
@@ -15,12 +15,12 @@ echo
 echo "Homebrew Cask Formula:"
 echo "----------------------"
 
-cat << EOF
+cat <<EOF
 cask "psst" do
   version "${VERSION}"
   sha256 "${SHA256}"
 
-  url "https://github.com/jpochyla/psst/releases/download/v#{version}/Psst-#{version}.dmg"
+  url "https://github.com/jpochyla/psst/releases/download/v#{version}/Psst.dmg"
   name "Psst"
   desc "Fast and multi-platform Spotify client"
   homepage "https://github.com/jpochyla/psst"

--- a/.homebrew/generate_formula.sh
+++ b/.homebrew/generate_formula.sh
@@ -5,14 +5,10 @@ set -eo pipefail
 REPO_OWNER="jpochyla"
 REPO_NAME="psst"
 
-LATEST_VERSION_TAG_NO_V=$(git ls-remote --tags "https://github.com/${REPO_OWNER}/${REPO_NAME}.git" | \
-    grep -Eo 'refs/tags/v[0-9]{4}\.[0-9]{2}\.[0-9]{2}-[a-f0-9]{7}$' | \
-    sed 's|refs/tags/v||' | sort -V | tail -n1)
-
-if [ -z "$LATEST_VERSION_TAG_NO_V" ]; then
-  echo "Error: No versioned tag found." >&2
-  exit 1
-fi
+LATEST_VERSION_TAG_NO_V=$(git ls-remote --tags "https://github.com/${REPO_OWNER}/${REPO_NAME}.git" |
+	grep -Eo 'refs/tags/v[0-9]{4}\.[0-9]{2}\.[0-9]{2}-[a-f0-9]{7}$' |
+	sed 's|refs/tags/v||' | sort -V | tail -n1)
+: "${LATEST_VERSION_TAG_NO_V:?Error: No versioned tag found.}"
 
 VERSION="$LATEST_VERSION_TAG_NO_V"
 TAG_WITH_V="v${VERSION}"
@@ -20,23 +16,13 @@ TAG_WITH_V="v${VERSION}"
 RELEASE_INFO_JSON=$(curl -sL "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/tags/${TAG_WITH_V}")
 
 DMG_URL=$(echo "$RELEASE_INFO_JSON" | jq -r '.assets[] | select(.name=="Psst.dmg") | .browser_download_url')
-CHECKSUMS_URL=$(echo "$RELEASE_INFO_JSON" | jq -r '.assets[] | select(.name=="checksums.txt") | .browser_download_url')
+: "${DMG_URL:?Error: Could not find Psst.dmg asset URL for tag ${TAG_WITH_V}.}"
 
-if [ -z "$DMG_URL" ] || [ "$DMG_URL" == "null" ]; then
-  echo "Error: Could not find Psst.dmg asset URL for tag ${TAG_WITH_V}." >&2
-  exit 1
-fi
-if [ -z "$CHECKSUMS_URL" ] || [ "$CHECKSUMS_URL" == "null" ]; then
-  echo "Error: Could not find checksums.txt asset URL for tag ${TAG_WITH_V}." >&2
-  exit 1
-fi
+CHECKSUMS_URL=$(echo "$RELEASE_INFO_JSON" | jq -r '.assets[] | select(.name=="checksums.txt") | .browser_download_url')
+: "${CHECKSUMS_URL:?Error: Could not find checksums.txt asset URL for tag ${TAG_WITH_V}.}"
 
 SHA256=$(curl -sL "$CHECKSUMS_URL" | grep '\./Psst.dmg/Psst.dmg$' | awk '{print $1}')
-
-if [ -z "$SHA256" ]; then
-  echo "Error: Could not find SHA256 for Psst.dmg in checksums.txt." >&2
-  exit 1
-fi
+: "${SHA256:?Error: Could not find SHA256 for Psst.dmg in checksums.txt.}"
 
 cat <<EOF
 cask "psst" do
@@ -46,7 +32,7 @@ cask "psst" do
   url "${DMG_URL}",
       verified: "github.com/${REPO_OWNER}/${REPO_NAME}/"
   name "Psst"
-  desc "Fast, native Spotify client"
+  desc "Fast and native Spotify client"
   homepage "https://github.com/${REPO_OWNER}/${REPO_NAME}/"
 
   livecheck do

--- a/.pkg/DEBIAN/control
+++ b/.pkg/DEBIAN/control
@@ -7,4 +7,4 @@ Priority: optional
 Homepage: https://github.com/jpochyla/psst
 Package-Type: deb
 Depends: libssl3 | libssl1.1, libgtk-3-0, libcairo2
-Description: Fast and multi-platform Spotify client with native GUI
+Description: Fast and native Spotify client

--- a/.pkg/psst.desktop
+++ b/.pkg/psst.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=Psst
-Comment=Fast and multi-platform Spotify client with native GUI
+Comment=Fast and native Spotify client
 GenericName=Music Player
 Icon=psst
 TryExec=psst-gui

--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@ Contributions are welcome!
 
 ## Download
 
-GitHub Actions automatically creates builds when new commits are pushed to the `main` branch.
-You can download the prebuilt binaries for x86_64 Windows, Linux (Ubuntu), and macOS.
+GitHub Actions automatically builds and releases new versions when changes are pushed to the `main` branch.
+You can download the latest release for Windows, Linux, and macOS from the [GitHub Releases page](https://github.com/jpochyla/psst/releases/latest).
 
-| Platform                                                                                                          |
-| ----------------------------------------------------------------------------------------------------------------- |
-| [Linux (x86_64)](https://nightly.link/jpochyla/psst/workflows/build/main/psst-gui-x86_64-unknown-linux-gnu.zip)   |
-| [Linux (aarch64)](https://nightly.link/jpochyla/psst/workflows/build/main/psst-gui-aarch64-unknown-linux-gnu.zip) |
-| [Debian Package (amd64)](https://nightly.link/jpochyla/psst/workflows/build/main/psst-deb-amd64.zip)              |
-| [Debian Package (arm64)](https://nightly.link/jpochyla/psst/workflows/build/main/psst-deb-arm64.zip)              |
-| [MacOS](https://nightly.link/jpochyla/psst/workflows/build/main/Psst.dmg.zip)                                     |
-| [Windows](https://nightly.link/jpochyla/psst/workflows/build/main/Psst.exe.zip)                                   |
+| Platform               | Download Link                                                                                            |
+| ---------------------- | -------------------------------------------------------------------------------------------------------- |
+| Linux (x86_64)         | [Download](https://github.com/jpochyla/psst/releases/latest/download/psst-gui-x86_64-unknown-linux-gnu)  |
+| Linux (aarch64)        | [Download](https://github.com/jpochyla/psst/releases/latest/download/psst-gui-aarch64-unknown-linux-gnu) |
+| Debian Package (amd64) | [Download](https://github.com/jpochyla/psst/releases/latest/download/psst_*_amd64.deb)                   |
+| Debian Package (arm64) | [Download](https://github.com/jpochyla/psst/releases/latest/download/psst_*_arm64.deb)                   |
+| macOS                  | [Download](https://github.com/jpochyla/psst/releases/latest/download/Psst-*.dmg)                         |
+| Windows                | [Download](https://github.com/jpochyla/psst/releases/latest/download/psst-gui.exe)                       |
 
 Unofficial builds of Psst are also available through the [AUR](https://aur.archlinux.org/packages/psst-git) and [Homebrew](https://formulae.brew.sh/cask/psst).
 

--- a/psst-gui/Cargo.toml
+++ b/psst-gui/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Jan Pochyla <jpochyla@gmail.com>"]
 edition = "2021"
 build = "build.rs"
-description = "Fast Spotify client with native GUI"
+description = "Fast and native Spotify client"
 repository = "https://github.com/jpochyla/psst"
 
 [features]
@@ -66,7 +66,7 @@ version = "0.1.0"
 resources = []
 copyright = "Copyright (c) Jan Pochyla 2024. All rights reserved."
 category = "Music"
-short_description = "Fast Spotify client with native GUI"
+short_description = "Fast and native Spotify client"
 long_description = """
-Small and efficient graphical music player for Spotify network.
+Small and efficient graphical music player for the Spotify network.
 """


### PR DESCRIPTION
This should make the releases far more consistent and clear.

- Automating GitHub releases (both versioned and `latest` tags) with an improved CI pipeline (away from nightly links)
- Introducing a script to auto-generate the Homebrew formula (I'll update after this gets merged)
- Updating README download links and standardizing application descriptions