### PR TITLE
Remove checksums

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,25 +135,12 @@ jobs:
             "target/release/bundle/osx/Psst.app"
         working-directory: psst-gui
 
-      - name: Generate DMG Checksum
-        if: runner.os == 'macOS'
-        run: |
-          shasum -a 256 "Psst.dmg" > "Psst.dmg.sha256"
-        working-directory: psst-gui
-
       - name: Upload macOS DMG
         uses: actions/upload-artifact@v4
         if: runner.os == 'macOS'
         with:
           name: Psst.dmg
           path: ./psst-gui/Psst.dmg
-
-      - name: Upload macOS DMG Checksum
-        uses: actions/upload-artifact@v4
-        if: runner.os == 'macOS'
-        with:
-          name: Psst.dmg.sha256
-          path: ./psst-gui/Psst.dmg.sha256
 
       - name: Make Linux Binary Executable
         if: runner.os == 'Linux'
@@ -311,11 +298,9 @@ jobs:
           delimiter=$(uuidgen)
           echo "release_files_list<<$delimiter" >> $GITHUB_OUTPUT
           echo "artifacts/Psst.dmg/Psst.dmg" >> $GITHUB_OUTPUT
-          echo "artifacts/Psst.dmg.sha256/Psst.dmg.sha256" >> $GITHUB_OUTPUT
           echo "artifacts/Psst.exe/psst-gui.exe" >> $GITHUB_OUTPUT
           echo "artifacts/psst-linux-x86_64" >> $GITHUB_OUTPUT
           echo "artifacts/psst-linux-aarch64" >> $GITHUB_OUTPUT
-          echo "artifacts/checksums.txt" >> $GITHUB_OUTPUT
           echo "artifacts/psst-deb-amd64/psst-amd64.deb" >> $GITHUB_OUTPUT
           echo "artifacts/psst-deb-arm64/psst-arm64.deb" >> $GITHUB_OUTPUT
           echo "$delimiter" >> $GITHUB_OUTPUT
@@ -346,33 +331,17 @@ jobs:
           fi
         working-directory: ${{ github.workspace }}
 
-      - name: Generate SHA256 checksums
-        run: |
-          cd artifacts
-          find . -type f | while read file; do
-            if [[ "$file" != *.sha256 && "$file" != "./checksums.txt" ]]; then
-              sha256sum "$file" >> checksums.txt
-            fi
-          done
-          echo "Checksums generated in artifacts/checksums.txt"
-        working-directory: ${{ github.workspace }} # Ensure cd artifacts works as expected
-
       - name: Prepare Release Body Data
         id: release_data
         run: |
           echo "CURRENT_DATE_STR=$(date)" >> $GITHUB_ENV
-          # Read checksums into a variable, handling potential newlines for multiline env var
-          CHECKSUMS=$(cat artifacts/checksums.txt)
-          echo "CHECKSUMS_CONTENT<<EOF" >> $GITHUB_ENV
-          echo "$CHECKSUMS" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
         working-directory: ${{ github.workspace }}
 
       - name: Create Main Release
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: softprops/action-gh-release@v2
         with:
-          name: Psst (rolling release - ${{ env.RELEASE_VERSION }})
+          name: Continuous release (${{ env.RELEASE_VERSION }})
           tag_name: rolling
           make_latest: true
           prerelease: false
@@ -384,9 +353,6 @@ jobs:
             Built: ${{ env.CURRENT_DATE_STR }}
             Workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-            **SHA256 Checksums:**
-            ```
-            ${{ env.CHECKSUMS_CONTENT }}
-            ```
+            See the release assets for SHA256 checksums.
           files: ${{ steps.set_paths.outputs.release_files_list }}
           generate_release_notes: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -333,83 +333,16 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           name: Continuous release (${{ env.RELEASE_VERSION }})
-          tag_name: rolling
           make_latest: true
           prerelease: false
           body: |
             This is a rolling release of Psst, published automatically on every commit to main.
+
             Version: ${{ env.RELEASE_VERSION }}
             Commit: ${{ github.sha }}
             Built: ${{ env.CURRENT_DATE_STR }}
             Workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-            See the release assets for SHA256 checksums.
-          files: artifacts/*
-          generate_release_notes: false
 
-  pr-release:
-    needs: [build, deb]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    if: github.event_name == 'pull_request'
-    steps:
-      - name: Set Version Info and Paths
-        id: set_paths
-        env:
-          FULL_SHA: ${{ github.sha }}
-        run: |
-          echo "BUILD_DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
-          echo "VERSION=0.1.0,$(date +'%Y%m%d.%H%M%S')" >> $GITHUB_ENV
-          SHORT_SHA=${FULL_SHA::7}
-          echo "RELEASE_VERSION=$(date +'%Y.%m.%d')-$SHORT_SHA" >> $GITHUB_ENV
-
-      - name: Download All Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-
-      - name: Prepare Linux Release Assets
-        run: |
-          if [ -f "artifacts/psst-x86_64-unknown-linux-gnu/psst" ]; then
-            mv "artifacts/psst-x86_64-unknown-linux-gnu/psst" "artifacts/psst-linux-x86_64" && \
-            rmdir "artifacts/psst-x86_64-unknown-linux-gnu"
-          fi
-          if [ -f "artifacts/psst-aarch64-unknown-linux-gnu/psst" ]; then
-            mv "artifacts/psst-aarch64-unknown-linux-gnu/psst" "artifacts/psst-linux-aarch64" && \
-            rmdir "artifacts/psst-aarch64-unknown-linux-gnu"
-          fi
-
-      - name: Prepare Release Body Data
-        id: release_data
-        run: |
-          echo "CURRENT_DATE_STR=$(date)" >> $GITHUB_ENV
-
-      - name: Prepare All Release Assets
-        id: prep_assets
-        run: |
-          V="${{ env.RELEASE_VERSION }}"
-          mv artifacts/Psst.dmg/Psst.dmg "artifacts/Psst-${V}.dmg"
-          mv artifacts/Psst.exe/psst-gui.exe "artifacts/Psst-${V}.exe"
-          mv artifacts/psst-linux-x86_64 "artifacts/psst-linux-x86_64-${V}"
-          mv artifacts/psst-linux-aarch64 "artifacts/psst-linux-aarch64-${V}"
-          mv artifacts/psst-deb-amd64/psst-amd64.deb "artifacts/psst-amd64-${V}.deb"
-          mv artifacts/psst-deb-arm64/psst-arm64.deb "artifacts/psst-arm64-${V}.deb"
-          ls -R artifacts
-
-      - name: Create PR Release
-        uses: softprops/action-gh-release@v2
-        with:
-          name: PR Test Build (${{ env.RELEASE_VERSION }})
-          tag_name: pr-${{ github.event.pull_request.number }}
-          make_latest: false
-          prerelease: true
-          draft: true
-          body: |
-            This is a test build for PR #${{ github.event.pull_request.number }}.
-            Version: ${{ env.RELEASE_VERSION }}
-            Commit: ${{ github.sha }}
-            Built: ${{ env.CURRENT_DATE_STR }}
-            Workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
             See the release assets for SHA256 checksums.
           files: artifacts/*
           generate_release_notes: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -284,6 +284,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     steps:
       - name: Set Version Info and Paths
         id: set_paths
@@ -294,51 +295,41 @@ jobs:
           echo "VERSION=0.1.0,$(date +'%Y%m%d.%H%M%S')" >> $GITHUB_ENV
           SHORT_SHA=${FULL_SHA::7}
           echo "RELEASE_VERSION=$(date +'%Y.%m.%d')-$SHORT_SHA" >> $GITHUB_ENV
-          # Use a delimiter for multiline output
-          delimiter=$(uuidgen)
-          echo "release_files_list<<$delimiter" >> $GITHUB_OUTPUT
-          echo "artifacts/Psst.dmg/Psst.dmg" >> $GITHUB_OUTPUT
-          echo "artifacts/Psst.exe/psst-gui.exe" >> $GITHUB_OUTPUT
-          echo "artifacts/psst-linux-x86_64" >> $GITHUB_OUTPUT
-          echo "artifacts/psst-linux-aarch64" >> $GITHUB_OUTPUT
-          echo "artifacts/psst-deb-amd64/psst-amd64.deb" >> $GITHUB_OUTPUT
-          echo "artifacts/psst-deb-arm64/psst-arm64.deb" >> $GITHUB_OUTPUT
-          echo "$delimiter" >> $GITHUB_OUTPUT
 
-      - name: Download all artifacts
+      - name: Download All Artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
 
       - name: Prepare Linux Release Assets
         run: |
-          # Prepare Linux x86_64 executable: artifacts/psst-x86_64-unknown-linux-gnu/psst -> artifacts/psst-linux-x86_64
           if [ -f "artifacts/psst-x86_64-unknown-linux-gnu/psst" ]; then
             mv "artifacts/psst-x86_64-unknown-linux-gnu/psst" "artifacts/psst-linux-x86_64" && \
-            rmdir "artifacts/psst-x86_64-unknown-linux-gnu" && \
-            echo "Linux x86_64 executable prepared: artifacts/psst-linux-x86_64"
-          else
-            echo "Warning: Linux x86_64 executable artifacts/psst-x86_64-unknown-linux-gnu/psst not found."
+            rmdir "artifacts/psst-x86_64-unknown-linux-gnu"
           fi
-
-          # Prepare Linux aarch64 executable: artifacts/psst-aarch64-unknown-linux-gnu/psst -> artifacts/psst-linux-aarch64
           if [ -f "artifacts/psst-aarch64-unknown-linux-gnu/psst" ]; then
             mv "artifacts/psst-aarch64-unknown-linux-gnu/psst" "artifacts/psst-linux-aarch64" && \
-            rmdir "artifacts/psst-aarch64-unknown-linux-gnu" && \
-            echo "Linux aarch64 executable prepared: artifacts/psst-linux-aarch64"
-          else
-            echo "Warning: Linux aarch64 executable artifacts/psst-aarch64-unknown-linux-gnu/psst not found."
+            rmdir "artifacts/psst-aarch64-unknown-linux-gnu"
           fi
-        working-directory: ${{ github.workspace }}
 
       - name: Prepare Release Body Data
         id: release_data
         run: |
           echo "CURRENT_DATE_STR=$(date)" >> $GITHUB_ENV
-        working-directory: ${{ github.workspace }}
+
+      - name: Prepare All Release Assets
+        id: prep_assets
+        run: |
+          V="${{ env.RELEASE_VERSION }}"
+          mv artifacts/Psst.dmg/Psst.dmg "artifacts/Psst-${V}.dmg"
+          mv artifacts/Psst.exe/psst-gui.exe "artifacts/Psst-${V}.exe"
+          mv artifacts/psst-linux-x86_64 "artifacts/psst-linux-x86_64-${V}"
+          mv artifacts/psst-linux-aarch64 "artifacts/psst-linux-aarch64-${V}"
+          mv artifacts/psst-deb-amd64/psst-amd64.deb "artifacts/psst-amd64-${V}.deb"
+          mv artifacts/psst-deb-arm64/psst-arm64.deb "artifacts/psst-arm64-${V}.deb"
+          ls -R artifacts
 
       - name: Create Main Release
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: softprops/action-gh-release@v2
         with:
           name: Continuous release (${{ env.RELEASE_VERSION }})
@@ -347,12 +338,78 @@ jobs:
           prerelease: false
           body: |
             This is a rolling release of Psst, published automatically on every commit to main.
-
             Version: ${{ env.RELEASE_VERSION }}
             Commit: ${{ github.sha }}
             Built: ${{ env.CURRENT_DATE_STR }}
             Workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
             See the release assets for SHA256 checksums.
-          files: ${{ steps.set_paths.outputs.release_files_list }}
+          files: artifacts/*
+          generate_release_notes: false
+
+  pr-release:
+    needs: [build, deb]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Set Version Info and Paths
+        id: set_paths
+        env:
+          FULL_SHA: ${{ github.sha }}
+        run: |
+          echo "BUILD_DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+          echo "VERSION=0.1.0,$(date +'%Y%m%d.%H%M%S')" >> $GITHUB_ENV
+          SHORT_SHA=${FULL_SHA::7}
+          echo "RELEASE_VERSION=$(date +'%Y.%m.%d')-$SHORT_SHA" >> $GITHUB_ENV
+
+      - name: Download All Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Prepare Linux Release Assets
+        run: |
+          if [ -f "artifacts/psst-x86_64-unknown-linux-gnu/psst" ]; then
+            mv "artifacts/psst-x86_64-unknown-linux-gnu/psst" "artifacts/psst-linux-x86_64" && \
+            rmdir "artifacts/psst-x86_64-unknown-linux-gnu"
+          fi
+          if [ -f "artifacts/psst-aarch64-unknown-linux-gnu/psst" ]; then
+            mv "artifacts/psst-aarch64-unknown-linux-gnu/psst" "artifacts/psst-linux-aarch64" && \
+            rmdir "artifacts/psst-aarch64-unknown-linux-gnu"
+          fi
+
+      - name: Prepare Release Body Data
+        id: release_data
+        run: |
+          echo "CURRENT_DATE_STR=$(date)" >> $GITHUB_ENV
+
+      - name: Prepare All Release Assets
+        id: prep_assets
+        run: |
+          V="${{ env.RELEASE_VERSION }}"
+          mv artifacts/Psst.dmg/Psst.dmg "artifacts/Psst-${V}.dmg"
+          mv artifacts/Psst.exe/psst-gui.exe "artifacts/Psst-${V}.exe"
+          mv artifacts/psst-linux-x86_64 "artifacts/psst-linux-x86_64-${V}"
+          mv artifacts/psst-linux-aarch64 "artifacts/psst-linux-aarch64-${V}"
+          mv artifacts/psst-deb-amd64/psst-amd64.deb "artifacts/psst-amd64-${V}.deb"
+          mv artifacts/psst-deb-arm64/psst-arm64.deb "artifacts/psst-arm64-${V}.deb"
+          ls -R artifacts
+
+      - name: Create PR Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: PR Test Build (${{ env.RELEASE_VERSION }})
+          tag_name: pr-${{ github.event.pull_request.number }}
+          make_latest: false
+          prerelease: true
+          draft: true
+          body: |
+            This is a test build for PR #${{ github.event.pull_request.number }}.
+            Version: ${{ env.RELEASE_VERSION }}
+            Commit: ${{ github.sha }}
+            Built: ${{ env.CURRENT_DATE_STR }}
+            Workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            See the release assets for SHA256 checksums.
+          files: artifacts/*
           generate_release_notes: false

--- a/.homebrew/generate_formula.sh
+++ b/.homebrew/generate_formula.sh
@@ -10,19 +10,18 @@ TAG_WITH_V="rolling" # Target the static rolling release tag
 RELEASE_INFO_JSON=$(curl -sL "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/tags/${TAG_WITH_V}")
 : "${RELEASE_INFO_JSON:?Error: Could not fetch release info for tag ${TAG_WITH_V}.}"
 
-# Extract the version from the release name, e.g., "Psst (rolling release - 2023.10.26-abcdefg)"
-VERSION=$(echo "$RELEASE_INFO_JSON" | jq -r '.name' | sed -n 's/^Psst (rolling release - \(.*\))$/\1/p')
+# Extract the version from the release name, e.g., "Continuous release (2023.10.26-abcdefg)"
+VERSION=$(echo "$RELEASE_INFO_JSON" | jq -r '.name' | sed -n 's/^Continuous release (\(.*\))$/\1/p')
 : "${VERSION:?Error: Could not extract version from release name for tag ${TAG_WITH_V}. Release name format might have changed.}"
 
-DMG_URL=$(echo "$RELEASE_INFO_JSON" | jq -r '.assets[] | select(.name=="Psst.dmg") | .browser_download_url')
+DMG_ASSET_JSON=$(echo "$RELEASE_INFO_JSON" | jq -r '.assets[] | select(.name=="Psst.dmg")')
+: "${DMG_ASSET_JSON:?Error: Could not find Psst.dmg asset for tag ${TAG_WITH_V}.}"
+
+DMG_URL=$(echo "$DMG_ASSET_JSON" | jq -r '.browser_download_url')
 : "${DMG_URL:?Error: Could not find Psst.dmg asset URL for tag ${TAG_WITH_V}.}"
 
-CHECKSUMS_URL=$(echo "$RELEASE_INFO_JSON" | jq -r '.assets[] | select(.name=="checksums.txt") | .browser_download_url')
-: "${CHECKSUMS_URL:?Error: Could not find checksums.txt asset URL for tag ${TAG_WITH_V}.}"
-
-# The checksums.txt contains paths like './Psst.dmg/Psst.dmg'
-SHA256=$(curl -sL "$CHECKSUMS_URL" | grep -E '(\./)?Psst\.dmg/Psst\.dmg$' | awk '{print $1}')
-: "${SHA256:?Error: Could not find SHA256 for Psst.dmg in checksums.txt.}"
+SHA256=$(echo "$DMG_ASSET_JSON" | jq -r '.digest' | sed 's/sha256://')
+: "${SHA256:?Error: Could not find SHA256 for Psst.dmg in release info.}"
 
 cat <<EOF
 cask "psst" do
@@ -39,8 +38,8 @@ cask "psst" do
     # For a rolling release, check the name of the 'rolling' tag's release page title
     url "https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/tag/rolling"
     strategy :page_match
-    # Extracts version like "2023.10.26-abcdefg" from release title "Psst (rolling release - 2023.10.26-abcdefg)"
-    regex(/Psst\s+\(rolling release\s+-\s+([^)]+)\)/i)
+    # Extracts version like "2023.10.26-abcdefg" from release title "Continuous release (2023.10.26-abcdefg)"
+    regex(/Continuous release\s+\(([^)]+)\)/i)
   end
 
   app "Psst.app"
@@ -48,7 +47,8 @@ cask "psst" do
   depends_on macos: ">= :big_sur"
 
   zap trash: [
-    "~/Library/Application Support/com.jpochyla.psst",
+    "~/Library/Application Support/Psst",
+    "~/Library/Caches/Psst",
     "~/Library/Caches/com.jpochyla.psst",
     "~/Library/HTTPStorages/com.jpochyla.psst",
     "~/Library/Preferences/com.jpochyla.psst.plist",

--- a/.homebrew/generate_formula.sh
+++ b/.homebrew/generate_formula.sh
@@ -14,14 +14,15 @@ RELEASE_INFO_JSON=$(curl -sL "https://api.github.com/repos/${REPO_OWNER}/${REPO_
 VERSION=$(echo "$RELEASE_INFO_JSON" | jq -r '.name' | sed -n 's/^Continuous release (\(.*\))$/\1/p')
 : "${VERSION:?Error: Could not extract version from release name for tag ${TAG_WITH_V}. Release name format might have changed.}"
 
-DMG_ASSET_JSON=$(echo "$RELEASE_INFO_JSON" | jq -r '.assets[] | select(.name=="Psst.dmg")')
-: "${DMG_ASSET_JSON:?Error: Could not find Psst.dmg asset for tag ${TAG_WITH_V}.}"
+DMG_NAME="Psst-${VERSION}.dmg"
+DMG_ASSET_JSON=$(echo "$RELEASE_INFO_JSON" | jq -r --arg DMG_NAME "$DMG_NAME" '.assets[] | select(.name==$DMG_NAME)')
+: "${DMG_ASSET_JSON:?Error: Could not find ${DMG_NAME} asset for tag ${TAG_WITH_V}.}"
 
 DMG_URL=$(echo "$DMG_ASSET_JSON" | jq -r '.browser_download_url')
-: "${DMG_URL:?Error: Could not find Psst.dmg asset URL for tag ${TAG_WITH_V}.}"
+: "${DMG_URL:?Error: Could not find ${DMG_NAME} asset URL for tag ${TAG_WITH_V}.}"
 
 SHA256=$(echo "$DMG_ASSET_JSON" | jq -r '.digest' | sed 's/sha256://')
-: "${SHA256:?Error: Could not find SHA256 for Psst.dmg in release info.}"
+: "${SHA256:?Error: Could not find SHA256 for ${DMG_NAME} in release info.}"
 
 cat <<EOF
 cask "psst" do


### PR DESCRIPTION
We don't need to generate digests anymore with https://github.blog/changelog/2025-06-03-releases-now-expose-digests-for-release-assets/

I think it would look cleaner just for the release title to be "Continuous release (date-sha)". I'm going to use this to update our brew formula.

This will also follow the suggestions made in the [brew formula PR](https://github.com/Homebrew/homebrew-cask/pull/215521#issuecomment-2970472280).