### PR TITLE
Prevent from crashing when pasting into Last.fm key/secret textboxes

### DIFF
--- a/psst-gui/src/data/config.rs
+++ b/psst-gui/src/data/config.rs
@@ -58,9 +58,7 @@ pub struct Authentication {
     pub password: String,
     pub access_token: String,
     pub result: Promise<(), (), String>,
-    #[data(ignore)]
     pub lastfm_api_key_input: String,
-    #[data(ignore)]
     pub lastfm_api_secret_input: String,
 }
 


### PR DESCRIPTION
fixes #611

I wouldn't know of a reason why  `lastfm_api_key_input` and `lastfm_api_secret_input` shouldn't be checked for sameness. As far as I understand, if they are marked as `ignore`, pasting some larger text won't update the input field's inner data model properly, hence the panic. 