### PR TITLE
Resolve podcast URLs in search bar as podcast shows instead of track albums

### DIFF
--- a/psst-gui/src/webapi/client.rs
+++ b/psst-gui/src/webapi/client.rs
@@ -910,6 +910,14 @@ impl WebApi {
 
 /// Show endpoints. (Podcasts)
 impl WebApi {
+    // https://developer.spotify.com/documentation/web-api/reference/get-a-show/
+    pub fn get_show(&self, id: &str) -> Result<Cached<Arc<Show>>, Error> {
+        let request = &RequestBuilder::new(format!("v1/shows/{}", id), Method::Get, None)
+            .query("market", "from_token");
+        let result = self.load_cached(request, "show", id)?;
+        Ok(result)
+    }
+
     // https://developer.spotify.com/documentation/web-api/reference/get-multiple-episodes
     pub fn get_episodes(
         &self,
@@ -1374,7 +1382,7 @@ impl WebApi {
             SpotifyUrl::Playlist(id) => Nav::PlaylistDetail(self.get_playlist(id)?.link()),
             SpotifyUrl::Artist(id) => Nav::ArtistDetail(self.get_artist(id)?.link()),
             SpotifyUrl::Album(id) => Nav::AlbumDetail(self.get_album(id)?.data.link(), None),
-            SpotifyUrl::Show(id) => Nav::AlbumDetail(self.get_album(id)?.data.link(), None),
+            SpotifyUrl::Show(id) => Nav::ShowDetail(self.get_show(id)?.data.link()),
             SpotifyUrl::Track(id) => {
                 let track = self.get_track(id)?;
                 let album = track.album.clone().ok_or_else(|| {


### PR DESCRIPTION
fixes #638 

This pull request adds a new podcast endpoint for retrieving a show by its id. This is not to be confused with the separate endpoint for retrieving the show's episode list.

This endpoint can also be used to display further metadata such as show name, description, image(s), total episode count, publisher.