### PR TITLE
Just replace artifacts on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -320,13 +320,13 @@ jobs:
       - name: Prepare All Release Assets
         id: prep_assets
         run: |
-          V="${{ env.RELEASE_VERSION }}"
-          mv artifacts/Psst.dmg/Psst.dmg "artifacts/Psst-${V}.dmg"
-          mv artifacts/Psst.exe/psst-gui.exe "artifacts/Psst-${V}.exe"
-          mv artifacts/psst-linux-x86_64 "artifacts/psst-linux-x86_64-${V}"
-          mv artifacts/psst-linux-aarch64 "artifacts/psst-linux-aarch64-${V}"
-          mv artifacts/psst-deb-amd64/psst-amd64.deb "artifacts/psst-amd64-${V}.deb"
-          mv artifacts/psst-deb-arm64/psst-arm64.deb "artifacts/psst-arm64-${V}.deb"
+          # Use simple, static filenames that get replaced on each push
+          mv artifacts/Psst.dmg/Psst.dmg "artifacts/Psst.dmg"
+          mv artifacts/Psst.exe/psst-gui.exe "artifacts/Psst.exe"
+          mv artifacts/psst-linux-x86_64 "artifacts/psst-linux-x86_64"
+          mv artifacts/psst-linux-aarch64 "artifacts/psst-linux-aarch64"
+          mv artifacts/psst-deb-amd64/psst-amd64.deb "artifacts/psst-amd64.deb"
+          mv artifacts/psst-deb-arm64/psst-arm64.deb "artifacts/psst-arm64.deb"
           ls -R artifacts
 
       - name: Create Main Release

--- a/.homebrew/generate_formula.sh
+++ b/.homebrew/generate_formula.sh
@@ -5,57 +5,24 @@ set -eo pipefail
 REPO_OWNER="jpochyla"
 REPO_NAME="psst"
 
-# Get the latest release
-RELEASE_INFO_JSON=$(curl -sL "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest")
-: "${RELEASE_INFO_JSON:?Error: Could not fetch latest release info.}"
-
-# Find the latest Psst.dmg, get its version, URL, and SHA256
-DATA=$(echo "$RELEASE_INFO_JSON" | jq -r '
-  if .assets then
-    .assets[]
-    | select(.name | test("Psst-.*\\.dmg$"))
-    | .name + " " + .browser_download_url + " " + .digest
-  else
-    empty
-  end
-' | sort -V | tail -n 1)
-
-# Check if we got data
-: "${DATA:?Error: Could not find a matching Psst.dmg asset.}"
-
-# Extract variables from the data
-DMG_NAME=$(echo "$DATA" | awk '{print $1}')
-DMG_URL=$(echo "$DATA" | awk '{print $2}')
-SHA256=$(echo "$DATA" | awk '{print $3}' | sed 's/sha256://')
-
-VERSION=$(echo "$DMG_NAME" | sed -n 's/^Psst-\(.*\)\.dmg$/\1/p')
-: "${VERSION:?Error: Could not extract version from DMG name.}"
-
 cat <<EOF
 cask "psst" do
-  version "${VERSION}"
-  sha256 "${SHA256}"
+  version :latest
+  sha256 :no_check
 
-  url "${DMG_URL}",
-      verified: "github.com/${REPO_OWNER}/${REPO_NAME}/"
+  url "https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/latest/download/Psst.dmg"
   name "Psst"
   desc "Fast and native Spotify client"
   homepage "https://github.com/${REPO_OWNER}/${REPO_NAME}/"
 
-  livecheck do
-    url "https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/latest"
-    strategy :github_latest
-    regex(%r{href=.*?/Psst-([^/]+?)\.dmg}i)
-  end
+  depends_on macos: ">= :big_sur"
 
   app "Psst.app"
 
-  depends_on macos: ">= :big_sur"
-
   zap trash: [
     "~/Library/Application Support/Psst",
-    "~/Library/Caches/Psst",
     "~/Library/Caches/com.jpochyla.psst",
+    "~/Library/Caches/Psst",
     "~/Library/HTTPStorages/com.jpochyla.psst",
     "~/Library/Preferences/com.jpochyla.psst.plist",
     "~/Library/Saved Application State/com.jpochyla.psst.savedState",


### PR DESCRIPTION
It's a little bit annoying but given that we're on GitHub where artifacts are not guaranteed to be kept we don't really have a nice way of keeping the history of our nightly builds. The brew file for Psst is:

```rb
cask "psst" do
  version :latest
  sha256 :no_check

  url "https://github.com/jpochyla/psst/releases/latest/download/Psst.dmg"
  name "Psst"
  desc "Spotify client"
  homepage "https://github.com/jpochyla/psst/"

  depends_on macos: ">= :big_sur"

  app "Psst.app"

  zap trash: [
    "~/Library/Application Support/Psst",
    "~/Library/Caches/com.jpochyla.psst",
    "~/Library/Caches/Psst",
    "~/Library/HTTPStorages/com.jpochyla.psst",
    "~/Library/Preferences/com.jpochyla.psst.plist",
    "~/Library/Saved Application State/com.jpochyla.psst.savedState",
  ]
end
```

So right now its not updated until we provide a `Psst.dmg` in the release.

Eventually this could all be resolved by adding semvar releases. I think we should probably do this given this is not a stable way of providing backwards compatibility. 