### PR TITLE
Add play button to album and playlist views

### DIFF
--- a/psst-gui/src/cmd.rs
+++ b/psst-gui/src/cmd.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::{
-    data::{Nav, PlaybackPayload, QueueBehavior, QueueEntry},
+    data::{AlbumLink, Nav, PlaybackPayload, PlaylistLink, QueueBehavior, QueueEntry},
     ui::find::Find,
 };
 
@@ -46,6 +46,8 @@ pub const PLAYBACK_BLOCKED: Selector = Selector::new("app.playback-blocked");
 pub const PLAYBACK_STOPPED: Selector = Selector::new("app.playback-stopped");
 
 // Playback control
+pub const PLAY_ALBUM: Selector<AlbumLink> = Selector::new("app.play-album");
+pub const PLAY_PLAYLIST: Selector<PlaylistLink> = Selector::new("app.play-playlist");
 pub const PLAY: Selector<usize> = Selector::new("app.play-index");
 pub const PLAY_TRACKS: Selector<PlaybackPayload> = Selector::new("app.play-tracks");
 pub const PLAY_PREVIOUS: Selector = Selector::new("app.play-previous");

--- a/psst-gui/src/data/config.rs
+++ b/psst-gui/src/data/config.rs
@@ -58,9 +58,7 @@ pub struct Authentication {
     pub password: String,
     pub access_token: String,
     pub result: Promise<(), (), String>,
-    #[data(ignore)]
     pub lastfm_api_key_input: String,
-    #[data(ignore)]
     pub lastfm_api_secret_input: String,
 }
 

--- a/psst-gui/src/data/playlist.rs
+++ b/psst-gui/src/data/playlist.rs
@@ -93,7 +93,7 @@ where
         total: Option<usize>,
     }
 
-    Ok(PlaylistTracksRef::deserialize(deserializer)?.total)
+    Ok(Option::<PlaylistTracksRef>::deserialize(deserializer)?.and_then(|r| r.total))
 }
 
 fn deserialize_description<'de, D>(deserializer: D) -> Result<Arc<str>, D::Error>

--- a/psst-gui/src/data/utils.rs
+++ b/psst-gui/src/data/utils.rs
@@ -42,7 +42,9 @@ impl<T: Data> Cached<T> {
 }
 
 #[derive(Deserialize)]
+#[serde(bound(deserialize = "T: serde::Deserialize<'de>"))]
 pub struct Page<T: Clone> {
+    #[serde(deserialize_with = "deserialize_ignore_nulls")]
     pub items: Vector<T>,
     pub limit: usize,
     pub offset: usize,
@@ -156,6 +158,16 @@ where
     struct Wrapper(#[serde(deserialize_with = "deserialize_date")] Date);
 
     Ok(Option::deserialize(deserializer)?.map(|Wrapper(val)| val))
+}
+
+pub fn deserialize_ignore_nulls<'de, D, T>(deserializer: D) -> Result<Vector<T>, D::Error>
+where
+    T: Clone,
+    T: Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    let items: Vec<Option<T>> = Vec::deserialize(deserializer)?;
+    Ok(items.into_iter().flatten().collect())
 }
 
 pub fn deserialize_first_page<'de, D, T>(deserializer: D) -> Result<Vector<T>, D::Error>

--- a/psst-gui/src/delegate.rs
+++ b/psst-gui/src/delegate.rs
@@ -3,7 +3,9 @@ use druid::{
     commands, AppDelegate, Application, Command, DelegateCtx, Env, Event, Handled, Target,
     WindowDesc, WindowId,
 };
+use rand::seq::IndexedRandom;
 use std::fs;
+use std::sync::Arc;
 use threadpool::ThreadPool;
 
 use crate::ui::playlist::{
@@ -13,7 +15,7 @@ use crate::ui::theme;
 use crate::ui::DOWNLOAD_ARTWORK;
 use crate::{
     cmd,
-    data::{AppState, Config},
+    data::{AppState, Config, Track},
     ui,
     webapi::WebApi,
     widget::remote_image,
@@ -139,6 +141,30 @@ impl AppDelegate<AppState> for Delegate {
         data: &mut AppState,
         _env: &Env,
     ) -> Handled {
+        if let Some(album_link) = cmd.get(cmd::PLAY_ALBUM) {
+            if let Some(album) = data.album_detail.album.resolved() {
+                play_items(
+                    ctx,
+                    album.data.tracks.iter().cloned().collect(),
+                    crate::data::PlaybackOrigin::Album(album_link.clone()),
+                    data.playback.queue_behavior,
+                    |t: Arc<Track>| crate::data::Playable::Track(t),
+                );
+            }
+            return Handled::Yes;
+        }
+        if let Some(playlist_link) = cmd.get(cmd::PLAY_PLAYLIST) {
+            if let Some(tracks) = data.playlist_detail.tracks.resolved() {
+                play_items(
+                    ctx,
+                    tracks.tracks.iter().cloned().collect(),
+                    crate::data::PlaybackOrigin::Playlist(playlist_link.clone()),
+                    data.playback.queue_behavior,
+                    |t: Arc<Track>| crate::data::Playable::Track(t),
+                );
+            }
+            return Handled::Yes;
+        }
         if cmd.is(cmd::SHOW_CREDITS_WINDOW) {
             let _window_id = self.show_credits(ctx);
             if let Some(track) = cmd.get(cmd::SHOW_CREDITS_WINDOW) {
@@ -324,4 +350,33 @@ impl Delegate {
             Handled::No
         }
     }
+}
+
+fn play_items<T, F>(
+    ctx: &mut DelegateCtx,
+    items: Vec<T>,
+    origin: crate::data::PlaybackOrigin,
+    queue_behavior: crate::data::QueueBehavior,
+    to_playable: F,
+) where
+    F: Fn(T) -> crate::data::Playable,
+{
+    if items.is_empty() {
+        return;
+    }
+    let playables: Vec<_> = items.into_iter().map(to_playable).collect();
+    let position = if queue_behavior == crate::data::QueueBehavior::Random {
+        (0..playables.len())
+            .collect::<Vec<_>>()
+            .choose(&mut rand::rng())
+            .copied()
+            .unwrap_or(0)
+    } else {
+        0
+    };
+    ctx.submit_command(crate::cmd::PLAY_TRACKS.with(crate::data::PlaybackPayload {
+        items: playables.into(),
+        origin,
+        position,
+    }));
 }

--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -248,6 +248,7 @@ fn root_widget() -> impl Widget<AppState> {
         .with_child(topbar_back_button_widget())
         .with_flex_child(topbar_title_widget(), 1.0)
         .with_child(topbar_sort_widget())
+        .with_child(topbar_play_button_widget())
         .background(Border::Bottom.with_color(theme::BACKGROUND_DARK));
 
     let main = Flex::column()
@@ -492,6 +493,32 @@ fn volume_slider() -> impl Widget<AppState> {
                 data.playback.volume = (data.playback.volume + scaled_delta).clamp(0.0, 1.0);
             },
         )
+}
+
+fn topbar_play_button_widget() -> impl Widget<AppState> {
+    let play_button = icons::PLAY
+        .scale((theme::grid(2.0), theme::grid(2.0)))
+        .padding(theme::grid(1.0))
+        .link()
+        .rounded(theme::BUTTON_BORDER_RADIUS)
+        .on_left_click(|ctx, _, data: &mut AppState, _| match &data.nav {
+            Nav::AlbumDetail(link, _) => {
+                ctx.submit_command(cmd::PLAY_ALBUM.with(link.clone()));
+            }
+            Nav::PlaylistDetail(link) => {
+                ctx.submit_command(cmd::PLAY_PLAYLIST.with(link.clone()));
+            }
+            _ => {}
+        });
+
+    Either::new(
+        |data: &AppState, _| {
+            matches!(data.nav, Nav::AlbumDetail(..)) || matches!(data.nav, Nav::PlaylistDetail(..))
+        },
+        play_button,
+        Empty,
+    )
+    .padding((0.0, 0.0, theme::grid(1.0), 0.0))
 }
 
 fn topbar_sort_widget() -> impl Widget<AppState> {

--- a/psst-gui/src/webapi/client.rs
+++ b/psst-gui/src/webapi/client.rs
@@ -329,8 +329,8 @@ impl WebApi {
         #[derive(Deserialize)]
         #[serde(rename_all = "camelCase")]
         pub struct Section {
-            data: SectionData,
-            section_items: SectionItems,
+            data: Option<SectionData>,
+            section_items: Option<SectionItems>,
         }
 
         #[derive(Deserialize)]
@@ -490,9 +490,12 @@ impl WebApi {
             .sections
             .iter()
             .for_each(|section| {
-                title = section.data.title.text.clone().into();
+                let (Some(data), Some(section_items)) = (&section.data, &section.section_items) else {
+                    return;
+                };
+                title = data.title.text.clone().into();
 
-                section.section_items.items.iter().for_each(|item| {
+                section_items.items.iter().for_each(|item| {
                     let Some(uri) = &item.content.data.uri else {
                         return;
                     };
@@ -1116,8 +1119,9 @@ impl WebApi {
 impl WebApi {
     pub fn get_user_info(&self) -> Result<(String, String), Error> {
         #[derive(Deserialize, Clone, Data)]
+        #[serde(rename_all = "camelCase")]
         struct User {
-            region: String,
+            country_code: String,
             timezone: String,
         }
         let token = self.access_token()?;
@@ -1125,12 +1129,12 @@ impl WebApi {
         let request = &RequestBuilder::new("json".to_string(), Method::Get, None)
             .set_protocol("http")
             .set_base_uri("ip-api.com")
-            .query("fields", "260")
+            .query("fields", "countryCode,timezone")
             .header("Authorization", format!("Bearer {token}"));
 
         let result: Cached<User> = self.load_cached(request, "user-info", "usrinfo")?;
 
-        Ok((result.data.region, result.data.timezone))
+        Ok((result.data.country_code, result.data.timezone))
     }
 
     pub fn get_section(&self, section_uri: &str) -> Result<MixedView, Error> {


### PR DESCRIPTION
Introduces a play button to both album and playlist detail views, allowing users to start playback directly from these screens. Implements new commands and delegate handling to support playing all tracks from an album or playlist, respecting the current queue behavior (e.g., random or sequential).

> Not sure about code quality or used practice

close https://github.com/jpochyla/psst/issues/656

![{962628E1-A986-46AE-A412-615344ABF36F}](https://github.com/user-attachments/assets/fb19cf30-29bf-40e8-b9a1-5ef006d6719c)
![{5470D146-7C18-4D6E-8B40-FE0B4A3F4F56}](https://github.com/user-attachments/assets/fe26b487-25a6-41c3-948a-579a8777c9b5)
