### PR TITLE
Add WebP image support to client and dependencies

### DIFF
--- a/psst-gui/Cargo.toml
+++ b/psst-gui/Cargo.toml
@@ -42,6 +42,7 @@ druid = { git = "https://github.com/jpochyla/druid", branch = "psst", features =
   "image",
   "jpeg",
   "png",
+  "webp",
   "serde",
 ] }
 druid-enums = { git = "https://github.com/jpochyla/druid-enums" }

--- a/psst-gui/src/webapi/client.rs
+++ b/psst-gui/src/webapi/client.rs
@@ -1479,6 +1479,7 @@ impl WebApi {
         let format = match infer::get(body.as_slice()) {
             Some(kind) if kind.mime_type() == "image/jpeg" => Some(ImageFormat::Jpeg),
             Some(kind) if kind.mime_type() == "image/png" => Some(ImageFormat::Png),
+            Some(kind) if kind.mime_type() == "image/webp" => Some(ImageFormat::WebP),
             _ => None,
         };
 


### PR DESCRIPTION
Added 'webp' to the image crate features in Cargo.toml and updated the WebApi client to recognize and handle WebP images. This enables the application to process WebP image formats in addition to JPEG and PNG.