### PR TITLE
feat: adjust volume mapping for linear perceived loudness

### DIFF
--- a/psst-core/src/audio/output/cpal.rs
+++ b/psst-core/src/audio/output/cpal.rs
@@ -260,7 +260,7 @@ impl StreamCallback {
             let written = self.source.write(output);
 
             // Apply scaled global volume level.
-            let scaled_volume = self.volume.pow(4);
+            let scaled_volume = self.volume.pow(2);
             output[..written]
                 .iter_mut()
                 .for_each(|s| *s *= scaled_volume);


### PR DESCRIPTION
This improves how the volume control works by making the loudness feel more natural to our ears.
Instead of changing volume linearly (which sounds uneven), it applies a logarithmic curve so that when you move the volume slider, the perceived loudness changes smoothly and evenly.