### PR TITLE
Fix truncation on playlist descriptions & album/search titles

### DIFF
--- a/psst-gui/src/ui/album.rs
+++ b/psst-gui/src/ui/album.rs
@@ -52,7 +52,7 @@ fn loaded_detail_widget() -> impl Widget<WithCtx<Cached<Arc<Album>>>> {
         .with_text_size(theme::TEXT_SIZE_SMALL);
 
     let album_label = Label::raw()
-        .with_line_break_mode(LineBreaking::WordWrap)
+        .with_line_break_mode(LineBreaking::Clip)
         .with_text_size(theme::TEXT_SIZE_SMALL)
         .with_text_color(theme::PLACEHOLDER_COLOR)
         .lens(Album::label.in_arc());
@@ -70,7 +70,7 @@ fn loaded_detail_widget() -> impl Widget<WithCtx<Cached<Arc<Album>>>> {
         .with_spacer(theme::grid(4.2))
         .with_child(album_cover)
         .with_default_spacer()
-        .with_child(album_info.lens(Ctx::data()));
+        .with_flex_child(album_info.lens(Ctx::data()), 1.0);
 
     let album_tracks = playable::list_widget(playable::Display {
         track: track::Display {

--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -21,7 +21,10 @@ use druid::widget::Controller;
 use druid::KbKey;
 use druid::{
     im::Vector,
-    widget::{CrossAxisAlignment, Either, Flex, Label, List, Scroll, Slider, Split, ViewSwitcher},
+    widget::{
+        CrossAxisAlignment, Either, Flex, Label, LineBreaking, List, Scroll, Slider, Split,
+        ViewSwitcher,
+    },
     Color, Env, Insets, Key, LensExt, Menu, MenuItem, Selector, Widget, WidgetExt, WindowDesc,
 };
 use druid_shell::Cursor;
@@ -243,7 +246,7 @@ fn root_widget() -> impl Widget<AppState> {
     let topbar = Flex::row()
         .must_fill_main_axis(true)
         .with_child(topbar_back_button_widget())
-        .with_child(topbar_title_widget())
+        .with_flex_child(topbar_title_widget(), 1.0)
         .with_child(topbar_sort_widget())
         .background(Border::Bottom.with_color(theme::BACKGROUND_DARK));
 
@@ -605,7 +608,7 @@ fn sorting_menu(app_state: &AppState) -> Menu<AppState> {
 fn topbar_title_widget() -> impl Widget<AppState> {
     Flex::row()
         .cross_axis_alignment(CrossAxisAlignment::Center)
-        .with_child(route_title_widget())
+        .with_flex_child(route_title_widget(), 1.0)
         .with_spacer(theme::grid(0.5))
         .with_child(route_icon_widget())
         .lens(AppState::nav)
@@ -632,6 +635,7 @@ fn route_icon_widget() -> impl Widget<Nav> {
 
 fn route_title_widget() -> impl Widget<Nav> {
     Label::dynamic(|nav: &Nav, _| nav.title())
+        .with_line_break_mode(LineBreaking::Clip)
         .with_font(theme::UI_FONT_MEDIUM)
         .with_text_size(theme::TEXT_SIZE_LARGE)
 }

--- a/psst-gui/src/ui/playlist.rs
+++ b/psst-gui/src/ui/playlist.rs
@@ -453,7 +453,7 @@ fn playlist_info_widget() -> impl Widget<WithCtx<Playlist>> {
         |p: &Playlist, _| !p.description.is_empty(),
         Flex::column().with_default_spacer().with_child(
             Label::dynamic(|p: &Playlist, _| p.description.to_string())
-                .with_line_break_mode(LineBreaking::WordWrap)
+                .with_line_break_mode(LineBreaking::Clip)
                 .with_text_size(theme::TEXT_SIZE_SMALL)
                 .with_text_color(theme::PLACEHOLDER_COLOR),
         ),
@@ -494,7 +494,7 @@ fn playlist_info_widget() -> impl Widget<WithCtx<Playlist>> {
     Flex::row()
         .with_child(playlist_cover)
         .with_default_spacer()
-        .with_child(playlist_info.lens(Ctx::data()))
+        .with_flex_child(playlist_info.lens(Ctx::data()), 1.0)
 }
 
 fn async_tracks_widget() -> impl Widget<AppState> {

--- a/psst-gui/src/ui/playlist.rs
+++ b/psst-gui/src/ui/playlist.rs
@@ -488,8 +488,7 @@ fn playlist_info_widget() -> impl Widget<WithCtx<Playlist>> {
         .with_default_spacer()
         .with_child(track_count_label)
         .with_child(description_widget)
-        .with_child(visibility_widget)
-        .padding(theme::grid(1.0));
+        .with_child(visibility_widget);
 
     Flex::row()
         .with_child(playlist_cover)


### PR DESCRIPTION
Before long titles or descriptions would not respect the gutters/padding:

<img width="375"  alt="image" src="https://github.com/user-attachments/assets/8a1e260b-d880-4548-ab6a-3c4d592df051" /><img width="375" alt="image" src="https://github.com/user-attachments/assets/b74d1de3-36ad-4c6f-9828-bb5f6d28ff07" />


---

Now they do, it also means the sorting is anchored right (which I think is fine):

<img width="375" alt="image" src="https://github.com/user-attachments/assets/9f9ce977-4622-4be2-87b6-06d0b0752d4f" />
