### PR TITLE
fix: use the urlencoding crate instead of manual replacement of special characters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4004,6 +4004,7 @@ dependencies = [
  "time-humanize",
  "ureq 3.0.11",
  "url",
+ "urlencoding",
  "winres",
 ]
 
@@ -5712,6 +5713,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/psst-gui/Cargo.toml
+++ b/psst-gui/Cargo.toml
@@ -34,6 +34,7 @@ time-humanize = { version = "0.1.3" }
 ureq = { version = "3.0.11", features = ["json", "socks-proxy"] }
 url = { version = "2.5.4" }
 infer = "0.19.0"
+urlencoding = { version = "2.1.3" }
 
 # GUI
 druid = { git = "https://github.com/jpochyla/druid", branch = "psst", features = [

--- a/psst-gui/src/webapi/client.rs
+++ b/psst-gui/src/webapi/client.rs
@@ -1336,9 +1336,10 @@ impl WebApi {
             shows: Option<Page<Arc<Show>>>,
         }
 
+        let encoded_query = urlencoding::encode(query);
         let type_query_param = topics.iter().map(SearchTopic::as_str).join(",");
         let request = &RequestBuilder::new("v1/search", Method::Get, None)
-            .query("q", query.replace(" ", "%20"))
+            .query("q", encoded_query)
             .query("type", &type_query_param)
             .query("limit", limit.to_string())
             .query("marker", "from_token");


### PR DESCRIPTION
Closes #624, as suggested in https://github.com/jpochyla/psst/issues/624#issuecomment-2966336601

It seems there's no other place that needs this encoding