### PR TITLE
fix: resolve #54 — Testers / maintainers of Linux and Windows platform needed

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,10 +18,12 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Environment**
+**Platform (please complete the following)**
 
-- OS:
-- Version:
+- OS: [e.g. macOS 14.0, Ubuntu 22.04, Windows 11]
+- Architecture: [e.g. x86_64, aarch64]
+- App Version: [e.g. 0.1.0]
+- Installation method: [e.g. built from source, AUR, Homebrew]
 
 **Additional context**
 Add any other context about the problem here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing to Psst
+
+Thank you for your interest in contributing to Psst! This guide will help you get started.
+
+## Project Structure
+
+Psst is organized as a Cargo workspace with three crates:
+
+- **psst-core** — Core audio playback, Spotify session management, and CDN access
+- **psst-gui** — Desktop GUI built with Druid
+- **psst-cli** — Command-line interface
+
+## Platform-Specific Code
+
+Psst runs on Linux, macOS, and Windows. Platform-specific code lives in:
+
+- **Linux**: Audio output via `cpal`, packaging scripts in `snap/`, desktop integration files in `.desktop` and `metainfo/`
+- **macOS**: Audio output via `cpal`, app bundling handled in build configuration
+- **Windows**: Audio output via `cpal`, installer and packaging configuration
+
+We are actively looking for **Linux and Windows platform maintainers** to help with:
+
+- Packaging and distribution
+- Platform-specific bug triage
+- CI/CD pipeline maintenance for each platform
+- Testing on target platforms
+
+## Getting Started
+
+1. Fork the repository and clone your fork
+2. Install Rust via [rustup](https://rustup.rs/)
+3. Install platform dependencies:
+   - **Linux**: `libssl-dev`, `libasound2-dev`, `libgtk-3-dev`
+   - **macOS**: Xcode command line tools
+   - **Windows**: Visual Studio Build Tools with C++ workload
+4. Build the project: `cargo build`
+5. Run the GUI: `cargo run --bin psst-gui`
+
+## Development Workflow
+
+1. Create a branch from `main` for your change
+2. Make focused, minimal changes that address a single concern
+3. Ensure `cargo build` succeeds on your platform
+4. Run `cargo fmt` to format code (see `.rustfmt.toml` for settings)
+5. Run `cargo clippy` and address any warnings
+6. Open a pull request with a clear description of the change
+
+## Code Style
+
+- Follow existing patterns in the codebase
+- Use `cargo fmt` with the project's `.rustfmt.toml`
+- Keep imports organized per `imports_granularity = "Crate"`
+
+## Reporting Issues
+
+- Search existing issues before opening a new one
+- Include your OS, Rust version, and steps to reproduce
+- For platform-specific bugs, tag the issue with the relevant platform
+
+## Becoming a Platform Maintainer
+
+If you are interested in helping maintain Psst on Linux or Windows, please open an issue expressing your interest. Platform maintainers help with:
+
+- Reproducing and triaging platform-specific bugs
+- Maintaining packaging and distribution for their platform
+- Reviewing platform-related pull requests
+- Ensuring CI passes on their platform

--- a/tests/contributing_doc_test.rs
+++ b/tests/contributing_doc_test.rs
@@ -1,0 +1,58 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn contributing_file_exists() {
+    let path = Path::new("CONTRIBUTING.md");
+    assert!(path.exists(), "CONTRIBUTING.md should exist in the repository root");
+}
+
+#[test]
+fn contributing_file_contains_platform_sections() {
+    let content = fs::read_to_string("CONTRIBUTING.md")
+        .expect("Should be able to read CONTRIBUTING.md");
+
+    assert!(content.contains("## Platform-Specific Code"),
+        "Should contain platform-specific code section");
+    assert!(content.contains("Linux"),
+        "Should mention Linux");
+    assert!(content.contains("Windows"),
+        "Should mention Windows");
+    assert!(content.contains("macOS"),
+        "Should mention macOS");
+}
+
+#[test]
+fn contributing_file_contains_project_structure() {
+    let content = fs::read_to_string("CONTRIBUTING.md")
+        .expect("Should be able to read CONTRIBUTING.md");
+
+    assert!(content.contains("## Project Structure"),
+        "Should contain project structure section");
+    assert!(content.contains("psst-core"),
+        "Should mention psst-core crate");
+    assert!(content.contains("psst-gui"),
+        "Should mention psst-gui crate");
+    assert!(content.contains("psst-cli"),
+        "Should mention psst-cli crate");
+}
+
+#[test]
+fn contributing_file_contains_maintainer_information() {
+    let content = fs::read_to_string("CONTRIBUTING.md")
+        .expect("Should be able to read CONTRIBUTING.md");
+
+    assert!(content.contains("Platform Maintainer"),
+        "Should contain information about becoming a platform maintainer");
+    assert!(content.contains("Linux and Windows platform maintainers"),
+        "Should call out need for Linux and Windows maintainers");
+}
+
+#[test]
+fn contributing_file_is_not_empty() {
+    let content = fs::read_to_string("CONTRIBUTING.md")
+        .expect("Should be able to read CONTRIBUTING.md");
+
+    assert!(content.len() > 500,
+        "CONTRIBUTING.md should have substantial content");
+}


### PR DESCRIPTION
## Summary

Combined multi-file contribution:

## Changes

- `CONTRIBUTING.md` *(new)*
- `.github/ISSUE_TEMPLATE/bug_report.md`
- `tests/contributing_doc_test.rs` *(new)*

## Why

`CONTRIBUTING.md`: The issue highlights a need for platform maintainers for Linux and Windows. A CONTRIBUTING.md file would help potential volunteers understand the project structure, platform-specific code locations, and how to get involved with platform maintenance. This directly addresses the issue by lowering the barrier to entry for new contributors.
