### PR TITLE
fix: resolve #721 — Fix: Search crashes due to recent Spotify API changes (null items, missing tracks/publisher)

### DIFF
--- a/psst-gui/src/data/playlist.rs
+++ b/psst-gui/src/data/playlist.rs
@@ -93,7 +93,7 @@ where
         total: Option<usize>,
     }
 
-    Ok(PlaylistTracksRef::deserialize(deserializer)?.total)
+    Ok(Option::<PlaylistTracksRef>::deserialize(deserializer)?.and_then(|r| r.total))
 }
 
 fn deserialize_description<'de, D>(deserializer: D) -> Result<Arc<str>, D::Error>

--- a/psst-gui/src/data/utils.rs
+++ b/psst-gui/src/data/utils.rs
@@ -43,6 +43,7 @@ impl<T: Data> Cached<T> {
 
 #[derive(Deserialize)]
 pub struct Page<T: Clone> {
+    #[serde(deserialize_with = "deserialize_ignore_nulls")]
     pub items: Vector<T>,
     pub limit: usize,
     pub offset: usize,
@@ -156,6 +157,16 @@ where
     struct Wrapper(#[serde(deserialize_with = "deserialize_date")] Date);
 
     Ok(Option::deserialize(deserializer)?.map(|Wrapper(val)| val))
+}
+
+pub fn deserialize_ignore_nulls<'de, D, T>(deserializer: D) -> Result<Vector<T>, D::Error>
+where
+    T: Clone,
+    T: Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    let items: Vec<Option<T>> = Vec::deserialize(deserializer)?;
+    Ok(items.into_iter().flatten().collect())
 }
 
 pub fn deserialize_first_page<'de, D, T>(deserializer: D) -> Result<Vector<T>, D::Error>


### PR DESCRIPTION
## Summary

Combined multi-file contribution:

## Changes

- `psst-gui/src/data/utils.rs`
- `psst-gui/src/data/playlist.rs`

## Why

`psst-gui/src/data/utils.rs`: Spotify's API now occasionally returns `null` entries in the `items` array of paginated responses (e.g., region-blocked tracks). The current deserialization expects every element to be a valid struct, causing a crash like "invalid type: null, expected struct Playlist". We need a custom deserializer that filters out null values from the items array.
