### PR TITLE
fix: resolve #595 — Save the volume level

### DIFF
--- a/psst-gui/src/data/config.rs
+++ b/psst-gui/src/data/config.rs
@@ -21,6 +21,10 @@ use serde::{Deserialize, Serialize};
 use super::{Nav, Promise, QueueBehavior, SliderScrollScale};
 use crate::ui::theme;
 
+fn default_volume() -> f64 {
+    1.0
+}
+
 #[derive(Clone, Debug, Data, Lens)]
 pub struct Preferences {
     pub active: PreferencesTab,
@@ -112,6 +116,7 @@ pub struct Config {
     credentials: Option<Credentials>,
     pub audio_quality: AudioQuality,
     pub theme: Theme,
+    #[serde(default = "default_volume")]
     pub volume: f64,
     pub last_route: Option<Nav>,
     pub queue_behavior: QueueBehavior,


### PR DESCRIPTION
## Summary

The application's configuration struct (which is serialized/deserialized to disk) needs a field to store the volume level so it persists across launches. This file likely contains the `Config` struct with serde derives that gets saved to a config file

Fixes #595

## Changes

- `psst-gui/src/data/config.rs`

## Why

`psst-gui/src/data/config.rs`: The application's configuration struct (which is serialized/deserialized to disk) needs a field to store the volume level so it persists across launches. This file likely contains the `Config` struct with serde derives that gets saved to a config file.
