### PR TITLE
Security: OAuth callback HTTP request line is read without length limit

### DIFF
--- a/psst-core/src/oauth.rs
+++ b/psst-core/src/oauth.rs
@@ -87,9 +87,27 @@ fn handle_callback_connection(
 ) -> bool {
     let mut reader = BufReader::new(&mut *stream);
     let mut request_line = String::new();
+    const MAX_REQUEST_LINE_LEN: usize = 8192; // 8 KiB limit
 
-    if reader.read_line(&mut request_line).is_err() {
-        return false;
+    // Read with a size limit to prevent memory exhaustion attacks
+    let mut bytes_read = 0;
+    let mut buf = [0u8; 1];
+    loop {
+        match reader.read(&mut buf) {
+            Ok(0) => break,
+            Ok(1) => {
+                bytes_read += 1;
+                if bytes_read > MAX_REQUEST_LINE_LEN {
+                    log::error!("Request line exceeds {MAX_REQUEST_LINE_LEN} bytes limit");
+                    return false;
+                }
+                request_line.push(buf[0] as char);
+                if buf[0] == b'\n' {
+                    break;
+                }
+            }
+            _ => return false,
+        }
     }
 
     if request_line.contains("favicon.ico") {


### PR DESCRIPTION
## Problem

The `handle_callback_connection` function uses `reader.read_line(&mut request_line)` with no bound on the size of the line an attacker can send. A malicious process on localhost can open a TCP connection to 127.0.0.1:8888 and stream gigabytes of data without a newline, causing unbounded memory allocation until the process is OOM-killed. While the listener only runs during the OAuth sign-in window, any local process or script can exploit this.


**Severity**: `medium`
**File**: `psst-core/src/oauth.rs`

## Solution

Read with a size limit using `BufRead::read_line` replacement or a manual loop with a cap. For example, limit to 8 KiB:


## Changes

- `psst-core/src/oauth.rs` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
