### PR TITLE
Quality: OAuth callback listener thread and TCP port leak on timeout

### DIFF
--- a/psst-core/src/oauth.rs
+++ b/psst-core/src/oauth.rs
@@ -64,6 +64,12 @@ pub fn listen_for_callback_parameter(
         Ok(r) => r,
         Err(e) => {
             log::error!("Timed out or channel error: {e}");
+            // Drop the sender to signal the thread to exit
+            drop(tx);
+            // Wait for thread completion to ensure listener is dropped
+            if handle.join().is_err() {
+                log::warn!("thread join failed");
+            }
             return Err(Error::from(e));
         }
     };


### PR DESCRIPTION
## Problem

When `listen_for_callback_parameter` times out via `rx.recv_timeout`, the function returns early with an error at step 4, skipping `handle.join()` at step 5. The spawned thread remains blocked on `listener.incoming()` (or on a slow `read_line`) indefinitely. Because the `TcpListener` is owned by the thread and never dropped, the port stays bound until the process exits. Any subsequent OAuth callback attempt that tries to bind the same port will fail with "address already in use", making the retry path dead.


**Severity**: `medium`
**File**: `psst-core/src/oauth.rs`

## Solution

Store the listener handle and forcibly clean it up on timeout. The simplest fix is to make the thread joinable even in the error path:


## Changes

- `psst-core/src/oauth.rs` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
