### PR TITLE
Fix search and playlist parsing crashes from Spotify API nulls and duplicate items

### DIFF
--- a/psst-gui/src/data/playlist.rs
+++ b/psst-gui/src/data/playlist.rs
@@ -32,8 +32,7 @@ pub struct Playlist {
     pub images: Option<Vector<Image>>,
     #[serde(deserialize_with = "deserialize_description")]
     pub description: Arc<str>,
-    #[serde(rename = "items")]
-    #[serde(alias = "tracks")]
+    #[serde(rename = "tracks")]
     #[serde(deserialize_with = "deserialize_track_count")]
     #[serde(default)]
     pub track_count: Option<usize>,
@@ -93,7 +92,8 @@ where
         total: Option<usize>,
     }
 
-    Ok(PlaylistTracksRef::deserialize(deserializer)?.total)
+    let opt: Option<PlaylistTracksRef> = Option::deserialize(deserializer)?;
+    Ok(opt.and_then(|r| r.total))
 }
 
 fn deserialize_description<'de, D>(deserializer: D) -> Result<Arc<str>, D::Error>

--- a/psst-gui/src/data/utils.rs
+++ b/psst-gui/src/data/utils.rs
@@ -43,6 +43,7 @@ impl<T: Data> Cached<T> {
 
 #[derive(Deserialize)]
 pub struct Page<T: Clone> {
+    #[serde(deserialize_with = "deserialize_ignore_nulls", bound = "T: serde::Deserialize<'de>")]
     pub items: Vector<T>,
     pub limit: usize,
     pub offset: usize,
@@ -179,4 +180,17 @@ where
 pub fn sanitize_html_string(text: &str) -> Arc<str> {
     let sanitized = sanitize_str(&DEFAULT, text).unwrap_or_default();
     Arc::from(sanitized.replace("&amp;", "&"))
+}
+
+pub fn deserialize_ignore_nulls<'de, D, T>(deserializer: D) -> Result<Vector<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de> + Clone,
+{
+    let opt_vec: Option<Vec<Option<T>>> = Option::deserialize(deserializer)?;
+    Ok(opt_vec
+        .unwrap_or_default()
+        .into_iter()
+        .flatten()
+        .collect())
 }


### PR DESCRIPTION
This PR fixes the crashes caused by recent Spotify Web API changes. It resolves the duplicate field "items" deserialization conflict on /me/playlists and search results, and implements a null-safe deserializer deserialize_ignore_nulls for Page<T> to handle unavailable or region-locked tracks.