### PR TITLE
Fix Web API auth, playlist parsing, and save/unsave track

### DIFF
--- a/psst-core/src/oauth.rs
+++ b/psst-core/src/oauth.rs
@@ -1,7 +1,8 @@
 use crate::error::Error;
 use oauth2::{
-    basic::BasicClient, reqwest::http_client, AuthUrl, AuthorizationCode, ClientId, CsrfToken,
-    PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, RefreshToken, Scope, TokenResponse, TokenUrl,
+    basic::BasicClient, reqwest::http_client, AuthType, AuthUrl, AuthorizationCode, ClientId,
+    CsrfToken, PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, RefreshToken, Scope, TokenResponse,
+    TokenUrl,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -176,6 +177,9 @@ fn create_oauth_client(client_id: &str, redirect_port: u16) -> BasicClient {
         Some(TokenUrl::new("https://accounts.spotify.com/api/token".to_string()).unwrap()),
     )
     .set_redirect_uri(RedirectUrl::new(redirect_uri).expect("Invalid redirect URL"))
+    // Spotify's PKCE public-client token endpoint expects `client_id` in the
+    // request body, not as an HTTP Basic auth header (the oauth2 crate default).
+    .set_auth_type(AuthType::RequestBody)
 }
 
 pub fn generate_session_auth_url(redirect_port: u16) -> (String, PkceCodeVerifier) {
@@ -274,7 +278,7 @@ pub fn exchange_webapi_code_for_token(
         .exchange_code(code)
         .set_pkce_verifier(pkce_verifier)
         .request(http_client)
-        .map_err(|e| Error::OAuthError(format!("Failed to exchange Web API code: {e}")))?;
+        .map_err(|e| Error::OAuthError(format!("Failed to exchange Web API code: {e:?}")))?;
 
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)

--- a/psst-gui/src/data/playlist.rs
+++ b/psst-gui/src/data/playlist.rs
@@ -32,8 +32,10 @@ pub struct Playlist {
     pub images: Option<Vector<Image>>,
     #[serde(deserialize_with = "deserialize_description")]
     pub description: Arc<str>,
-    #[serde(rename = "items")]
-    #[serde(alias = "tracks")]
+    // Spotify returns both a `tracks` object (with `total`) and, more recently,
+    // a separate `items` key on playlist objects. Matching both (rename + alias)
+    // makes serde error with "duplicate field `items`", so read only `tracks`.
+    #[serde(rename = "tracks")]
     #[serde(deserialize_with = "deserialize_track_count")]
     #[serde(default)]
     pub track_count: Option<usize>,

--- a/psst-gui/src/webapi/client.rs
+++ b/psst-gui/src/webapi/client.rs
@@ -1116,15 +1116,15 @@ impl WebApi {
 
     // https://developer.spotify.com/documentation/web-api/reference/save-to-library/
     pub fn save_track(&self, id: &str) -> Result<(), Error> {
-        let request = &RequestBuilder::new("v1/me/library", Method::Put, None)
-            .set_body(Some(json!({"uris": [format!("spotify:track:{id}")]})));
+        // Spotify's /v1/me/tracks takes the base62 ids as a query param, not a
+        // uris body. The old /v1/me/library + {"uris":[...]} form returns 400.
+        let request = &RequestBuilder::new("v1/me/tracks", Method::Put, None).query("ids", id);
         self.send_empty_json(request)
     }
 
     // https://developer.spotify.com/documentation/web-api/reference/remove-from-library/
     pub fn unsave_track(&self, id: &str) -> Result<(), Error> {
-        let request = &RequestBuilder::new("v1/me/library", Method::Delete, None)
-            .set_body(Some(json!({"uris": [format!("spotify:track:{id}")]})));
+        let request = &RequestBuilder::new("v1/me/tracks", Method::Delete, None).query("ids", id);
         self.send_empty_json(request)
     }
 


### PR DESCRIPTION
## Summary

Three small fixes for recent Spotify Web API breakage that currently make Web
API auth, playlist parsing, and liking a track fail.

### 1. `fix(oauth)`: send `client_id` in body for PKCE token exchange
Spotify's public-client (PKCE) token endpoint expects `client_id` in the request
body, not as an HTTP Basic auth header (the `oauth2` crate default). Without
`AuthType::RequestBody`, the Web API token exchange/refresh fails with an opaque
"Server returned error response". Also logs the underlying error with `{e:?}`.

### 2. `fix(playlist)`: read only `tracks` to avoid serde duplicate-field error
Spotify now returns both a `tracks` object and an `items` key on playlist
objects. Matching both via `rename` + `alias` makes serde fail with
`duplicate field \`items\``. Reading only `tracks` restores playlist loading.

### 3. `fix(webapi)`: use `/v1/me/tracks` for save/unsave track
`save_track`/`unsave_track` posted to `/v1/me/library` with a `{"uris":[...]}`
body. That endpoint expects `uris` as a **query** parameter, so the request
returns `HTTP 400 "Missing required field: uris"` and liking a track fails.
Switched to the documented `PUT`/`DELETE /v1/me/tracks?ids=<id>`.

Verified against the live API with a real token:

```
PUT /v1/me/library  {"uris":[...]}   -> 400 Missing required field: uris
PUT /v1/me/tracks?ids=<base62>       -> 200 OK
```

## Testing
- Builds clean in release (`cargo build --release -p psst-gui`).
- Web API token refresh succeeds; liking/unliking a track now works and the
  track appears in Liked Songs.

Note: `save_album`/`save_show` share the same `/v1/me/library` pattern and are
likely affected too, but are left out of this PR to keep it focused — happy to
follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
