### PR TITLE
fix(webapi): use /v1/me/tracks for save/unsave track (fixes 400)

### DIFF
--- a/psst-gui/src/webapi/client.rs
+++ b/psst-gui/src/webapi/client.rs
@@ -1116,15 +1116,15 @@ impl WebApi {
 
     // https://developer.spotify.com/documentation/web-api/reference/save-to-library/
     pub fn save_track(&self, id: &str) -> Result<(), Error> {
-        let request = &RequestBuilder::new("v1/me/library", Method::Put, None)
-            .set_body(Some(json!({"uris": [format!("spotify:track:{id}")]})));
+        // Spotify's /v1/me/tracks takes the base62 ids as a query param, not a
+        // uris body. The old /v1/me/library + {"uris":[...]} form returns 400.
+        let request = &RequestBuilder::new("v1/me/tracks", Method::Put, None).query("ids", id);
         self.send_empty_json(request)
     }
 
     // https://developer.spotify.com/documentation/web-api/reference/remove-from-library/
     pub fn unsave_track(&self, id: &str) -> Result<(), Error> {
-        let request = &RequestBuilder::new("v1/me/library", Method::Delete, None)
-            .set_body(Some(json!({"uris": [format!("spotify:track:{id}")]})));
+        let request = &RequestBuilder::new("v1/me/tracks", Method::Delete, None).query("ids", id);
         self.send_empty_json(request)
     }
 

--- a/psst-gui/src/webapi/client.rs
+++ b/psst-gui/src/webapi/client.rs
@@ -1117,7 +1117,7 @@ impl WebApi {
     // https://developer.spotify.com/documentation/web-api/reference/save-to-library/
     pub fn save_track(&self, id: &str) -> Result<(), Error> {
         // Spotify's /v1/me/tracks takes the base62 ids as a query param, not a
-        // uris body. The old /v1/me/library + {"uris":[...]} form returns 400.
+        // uris body.
         let request = &RequestBuilder::new("v1/me/tracks", Method::Put, None).query("ids", id);
         self.send_empty_json(request)
     }


### PR DESCRIPTION
Liking a track (save) returns **HTTP 400** against the current Spotify API.
The old call used `PUT /v1/me/library` with a `{"uris":[...]}` body, which now
responds `400 Missing required field: uris`.

The working endpoint is `PUT /v1/me/tracks?ids=<base62>` (and `DELETE` to
remove). Verified live against the API with a real token:

- `PUT /v1/me/library` + `{"uris":[...]}` → `400`
- `PUT /v1/me/tracks?ids=<id>` → `200`

`save_album`/`save_show` share the same old pattern and likely need the same
change, but are left out to keep this PR focused.

Split out of #737 per maintainer request.
