### PR TITLE
docs: instruct user to enable Web API in Spotify Developer Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Contributions are welcome!
 
 **Note:** A Spotify Premium account is required.
 
-> **ℹ️ As of February 2026, Spotify [changed developer access](https://developer.spotify.com/blog/2026-02-06-update-on-developer-access-and-platform-security), and Psst now requires your own Spotify Developer Client ID for Web API features (search, library, playlists).** Register an app at the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard) (redirect URI: `http://127.0.0.1:8888/login`), then enter its Client ID on Psst's sign-in screen.
+> **ℹ️ As of February 2026, Spotify [changed developer access](https://developer.spotify.com/blog/2026-02-06-update-on-developer-access-and-platform-security), and Psst now requires your own Spotify Developer Client ID for Web API features (search, library, playlists).** Register an app at the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard) (redirect URI: `http://127.0.0.1:8888/login` and enable Web API), then enter its Client ID on Psst's sign-in screen.
 
 [![Build](https://github.com/jpochyla/psst/actions/workflows/build.yml/badge.svg)](https://github.com/jpochyla/psst/actions)
 

--- a/psst-gui/src/webapi/client.rs
+++ b/psst-gui/src/webapi/client.rs
@@ -123,7 +123,7 @@ impl WebApi {
             }
         }
         Err(Error::WebApiError(
-            "No valid Web API token available".to_string(),
+            "No valid Web API token available. Did you enable Web API for the Spotify Developer Client?".to_string(),
         ))
     }
 


### PR DESCRIPTION
otherwise psst would be fetching for a web API token that spotify won't return, without pointing the user to a possible fix.