### PR TITLE
fix(webapi): persist the Web API token refreshed mid-session

### DIFF
--- a/psst-gui/src/cmd.rs
+++ b/psst-gui/src/cmd.rs
@@ -1,6 +1,6 @@
 use crate::data::Track;
 use druid::{Selector, WidgetId};
-use psst_core::{item_id::ItemId, player::item::PlaybackItem};
+use psst_core::{item_id::ItemId, oauth::WebApiToken, player::item::PlaybackItem};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -29,6 +29,7 @@ pub const FIND_IN_SAVED_TRACKS: Selector<Find> = Selector::new("find-in-saved-tr
 // Session
 pub const SESSION_CONNECT: Selector = Selector::new("app.session-connect");
 pub const LOG_OUT: Selector = Selector::new("app.log-out");
+pub const STORE_WEBAPI_TOKEN: Selector<WebApiToken> = Selector::new("app.store-webapi-token");
 
 // Navigation
 pub const NAVIGATE: Selector<Nav> = Selector::new("app.navigates");

--- a/psst-gui/src/delegate.rs
+++ b/psst-gui/src/delegate.rs
@@ -180,6 +180,12 @@ impl AppDelegate<AppState> for Delegate {
         } else if let Some(text) = cmd.get(cmd::GO_TO_URL) {
             let _ = open::that(text);
             Handled::Yes
+        } else if let Some(token) = cmd.get(cmd::STORE_WEBAPI_TOKEN) {
+            // Do not call back into `WebApi` here, it holds the token lock
+            // across the refresh and we would block the GUI until it finishes.
+            data.config.store_webapi_token(token.clone());
+            data.config.save();
+            Handled::Yes
         } else if let Handled::Yes = self.command_image(ctx, target, cmd, data) {
             Handled::Yes
         } else if let Some(link) = cmd.get(UNFOLLOW_PLAYLIST_CONFIRM) {

--- a/psst-gui/src/main.rs
+++ b/psst-gui/src/main.rs
@@ -103,6 +103,10 @@ fn main() {
         launcher = AppLauncher::with_window(window).configure_env(ui::theme::setup);
     };
 
+    // `WebApi` refreshes tokens on worker threads, but only the GUI thread can
+    // save them into the config.
+    WebApi::global().set_event_sink(launcher.get_external_handle());
+
     launcher
         .delegate(delegate)
         .launch(state)

--- a/psst-gui/src/ui/preferences.rs
+++ b/psst-gui/src/ui/preferences.rs
@@ -760,6 +760,9 @@ impl<W: Widget<AppState>> Controller<AppState, W> for Authenticate {
             Event::Command(cmd) if cmd.is(cmd::LOG_OUT) => {
                 data.config.clear_credentials();
                 data.config.clear_webapi_token();
+                // `WebApi` keeps its own copy and would save it right back into
+                // the config we just cleared.
+                crate::webapi::WebApi::global().set_webapi_credentials(None, None);
                 data.config.save();
                 data.session.shutdown();
                 ctx.submit_command(cmd::CLOSE_ALL_WINDOWS);

--- a/psst-gui/src/ui/preferences.rs
+++ b/psst-gui/src/ui/preferences.rs
@@ -760,8 +760,8 @@ impl<W: Widget<AppState>> Controller<AppState, W> for Authenticate {
             Event::Command(cmd) if cmd.is(cmd::LOG_OUT) => {
                 data.config.clear_credentials();
                 data.config.clear_webapi_token();
-                // `WebApi` keeps its own copy and would save it right back into
-                // the config we just cleared.
+                // `WebApi` holds an in-memory copy of the credentials that it
+                // persists back to the config on save, so clear it too.
                 crate::webapi::WebApi::global().set_webapi_credentials(None, None);
                 data.config.save();
                 data.session.shutdown();

--- a/psst-gui/src/webapi/client.rs
+++ b/psst-gui/src/webapi/client.rs
@@ -11,7 +11,7 @@ use std::{
 use druid::{
     im::Vector,
     image::{self, ImageFormat},
-    Data, ImageBuf,
+    Data, ExtEventSink, ImageBuf, Target,
 };
 
 use itertools::Itertools;
@@ -36,6 +36,7 @@ use ureq::{
 };
 
 use crate::{
+    cmd,
     data::{
         self, utils::sanitize_html_string, Album, AlbumType, Artist, ArtistAlbums, ArtistInfo,
         ArtistLink, ArtistOverview, ArtistStats, AudioAnalysis, Cached, DatePrecision, Episode,
@@ -62,6 +63,7 @@ pub struct WebApi {
     session: Mutex<Option<SessionService>>,
     login5: Login5,
     client_token_provider: ClientTokenProviderHandle,
+    event_sink: OnceLock<ExtEventSink>,
 }
 
 impl WebApi {
@@ -86,6 +88,7 @@ impl WebApi {
             session: Mutex::new(None),
             login5: Login5::new(Some(Arc::clone(&client_token_provider)), proxy_url),
             client_token_provider,
+            event_sink: OnceLock::new(),
         }
     }
 
@@ -108,6 +111,27 @@ impl WebApi {
     pub fn set_webapi_credentials(&self, client_id: Option<String>, token: Option<WebApiToken>) {
         *self.webapi_client_id.lock() = client_id;
         *self.webapi_token.lock() = token;
+    }
+
+    /// Install the handle used to send refreshed tokens back to the GUI thread.
+    pub fn set_event_sink(&self, sink: ExtEventSink) {
+        if self.event_sink.set(sink).is_err() {
+            log::warn!("event sink is already installed");
+        }
+    }
+
+    /// Send a refreshed token to the GUI thread, which owns the config.
+    fn persist_webapi_token(&self, token: WebApiToken) {
+        if let Some(sink) = self.event_sink.get() {
+            if sink
+                .submit_command(cmd::STORE_WEBAPI_TOKEN, token, Target::Global)
+                .is_err()
+            {
+                log::warn!("failed to submit the refreshed Web API token");
+            }
+        } else {
+            log::warn!("no event sink, the refreshed Web API token will not be saved");
+        }
     }
 
     /// Install the authenticated core session, used to mint the first-party
@@ -151,10 +175,9 @@ impl WebApi {
                 match oauth::refresh_webapi_token(client_id, refresh_token) {
                     Ok(new_token) => {
                         let access_token = new_token.access_token.clone();
-                        // NOTE: only updates the in-memory cache. The durable
-                        // copy in config.json is refreshed by Config on the
-                        // next save; if Spotify rotates the refresh token and
-                        // the process exits before then, the user must re-login.
+                        // Spotify revokes the previous refresh token on every
+                        // refresh, so the copy in the config is now dead.
+                        self.persist_webapi_token(new_token.clone());
                         *token_guard = Some(new_token);
                         return Ok(access_token);
                     }


### PR DESCRIPTION
## Problem
Spotify rotates the refresh token on every PKCE refresh and revokes the previous one. psst has two refresh paths and only one of them saves the result.

`Config::get_or_refresh_webapi_token()` runs once at startup and calls `save()`. `WebApi::access_token()` runs on worker threads for every API call and only updated its in-memory copy. Its comment claimed the durable copy would be "refreshed by Config on the next save", which was never true: `save()` serializes `Config::webapi_token`, a separate field that WebApi never touches. WebApi holds no reference to Config and no way to reach the GUI thread, so it could not persist anything at all.

So once a session runs past the one hour mark, WebApi refreshes, Spotify revokes the old token, the replacement lives only in memory, and config.json keeps a corpse. The next launch presents the revoked token and gets `invalid_grant`, and so does every launch after that, because nothing ever replaces it. Until you re-authenticate, Web API features stay dead.

## Follow up
We should type the `invalid_grant` response. `refresh_webapi_token()` collapses every failure into `Error::OAuthError(String)` built from the oauth2 error's Display and for a server response that Display is literally "Server returned error response", discarding the payload. So the log cannot tell a revoked token from a bad client ID or a network blip.
