### PR TITLE
feat(webapi): fetch artist info & related artists via pathfinder GraphQL

### DIFF
--- a/psst-gui/src/data/album.rs
+++ b/psst-gui/src/data/album.rs
@@ -48,13 +48,6 @@ impl Album {
         self.release_with_format(format_description!("[year]"))
     }
 
-    pub fn release_year_int(&self) -> usize {
-        self.release_year().parse::<usize>().unwrap_or_else(|err| {
-            log::error!("error parsing release year for {}: {}", self.name, err);
-            usize::MAX
-        })
-    }
-
     fn release_with_format(&self, format: &(impl Formattable + ?Sized)) -> String {
         self.release_date
             .as_ref()
@@ -116,7 +109,6 @@ pub enum AlbumType {
     Album,
     Single,
     Compilation,
-    AppearsOn,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Data, Deserialize)]

--- a/psst-gui/src/data/artist.rs
+++ b/psst-gui/src/data/artist.rs
@@ -9,8 +9,7 @@ use crate::data::{Album, Cached, Image, Promise};
 pub struct ArtistDetail {
     pub artist: Promise<Artist, ArtistLink>,
     pub albums: Promise<ArtistAlbums, ArtistLink>,
-    pub related_artists: Promise<Cached<Vector<Artist>>, ArtistLink>,
-    pub artist_info: Promise<ArtistInfo, ArtistLink>,
+    pub overview: Promise<Cached<ArtistOverview>, ArtistLink>,
 }
 
 #[derive(Clone, Data, Lens, Deserialize)]
@@ -40,6 +39,15 @@ pub struct ArtistAlbums {
     pub compilations: Vector<Arc<Album>>,
     pub appears_on: Vector<Arc<Album>>,
 }
+
+/// Everything the artist page reads out of a single `queryArtistOverview`
+/// response: the info panel and the related artists shown below the albums.
+#[derive(Clone, Data, Lens)]
+pub struct ArtistOverview {
+    pub info: ArtistInfo,
+    pub related: Vector<Artist>,
+}
+
 #[derive(Clone, Data, Lens)]
 pub struct ArtistInfo {
     pub main_image: Arc<str>,

--- a/psst-gui/src/data/mod.rs
+++ b/psst-gui/src/data/mod.rs
@@ -33,7 +33,7 @@ use druid::{
 use psst_core::{item_id::ItemId, session::SessionService};
 
 pub use crate::data::{
-    album::{Album, AlbumDetail, AlbumLink, AlbumType},
+    album::{Album, AlbumDetail, AlbumLink, AlbumType, DatePrecision},
     artist::{
         Artist, ArtistAlbums, ArtistDetail, ArtistInfo, ArtistLink, ArtistStats,
     },

--- a/psst-gui/src/data/mod.rs
+++ b/psst-gui/src/data/mod.rs
@@ -35,7 +35,7 @@ use psst_core::{item_id::ItemId, session::SessionService};
 pub use crate::data::{
     album::{Album, AlbumDetail, AlbumLink, AlbumType, DatePrecision},
     artist::{
-        Artist, ArtistAlbums, ArtistDetail, ArtistInfo, ArtistLink, ArtistStats,
+        Artist, ArtistAlbums, ArtistDetail, ArtistInfo, ArtistLink, ArtistOverview, ArtistStats,
     },
     config::{AudioQuality, Authentication, Config, Preferences, PreferencesTab, Theme},
     ctx::Ctx,
@@ -153,8 +153,7 @@ impl AppState {
             artist_detail: ArtistDetail {
                 artist: Promise::Empty,
                 albums: Promise::Empty,
-                related_artists: Promise::Empty,
-                artist_info: Promise::Empty,
+                overview: Promise::Empty,
             },
             playlist_detail: PlaylistDetail {
                 playlist: Promise::Empty,
@@ -204,10 +203,9 @@ impl AppState {
 
     pub fn refresh_all(&mut self) {
         self.album_detail.album = Promise::Empty;
-        self.artist_detail.artist_info = Promise::Empty;
+        self.artist_detail.overview = Promise::Empty;
         self.artist_detail.albums = Promise::Empty;
         self.artist_detail.artist = Promise::Empty;
-        self.artist_detail.related_artists = Promise::Empty;
         self.playlist_detail.playlist = Promise::Empty;
         self.playlist_detail.tracks = Promise::Empty;
         self.show_detail.episodes = Promise::Empty;

--- a/psst-gui/src/ui/artist.rs
+++ b/psst-gui/src/ui/artist.rs
@@ -1,5 +1,4 @@
 use druid::{
-    im::Vector,
     kurbo::Circle,
     widget::{CrossAxisAlignment, Either, Flex, Label, LabelText, LineBreaking, List, Scroll},
     Data, Insets, LensExt, LocalizedString, Menu, MenuItem, Selector, Size, UnitPoint, Widget,
@@ -9,8 +8,8 @@ use druid::{
 use crate::{
     cmd,
     data::{
-        AppState, Artist, ArtistAlbums, ArtistDetail, ArtistInfo, ArtistLink, Cached, Ctx, Nav,
-        WithCtx,
+        AppState, Artist, ArtistAlbums, ArtistDetail, ArtistInfo, ArtistLink, ArtistOverview,
+        Cached, Ctx, Nav, WithCtx,
     },
     ui::utils::{stat_row, InfoLayout},
     webapi::WebApi,
@@ -48,32 +47,33 @@ fn async_albums_widget() -> impl Widget<AppState> {
         )
 }
 
+/// Owns the single artist overview request for the whole page.
 fn async_artist_info() -> impl Widget<AppState> {
-    Async::new(utils::spinner_widget, artist_info_widget, || Empty)
-        .lens(
-            Ctx::make(
-                AppState::common_ctx,
-                AppState::artist_detail.then(ArtistDetail::artist_info),
-            )
-            .then(Ctx::in_promise()),
+    Async::new(
+        utils::spinner_widget,
+        || artist_info_widget().lens(Ctx::map(Cached::data.then(ArtistOverview::info))),
+        || Empty,
+    )
+    .lens(
+        Ctx::make(
+            AppState::common_ctx,
+            AppState::artist_detail.then(ArtistDetail::overview),
         )
-        .on_command_async(
-            LOAD_DETAIL,
-            |d| WebApi::global().get_artist_info(&d.id),
-            |_, data, d| data.artist_detail.artist_info.defer(d),
-            |_, data, r| data.artist_detail.artist_info.update(r),
-        )
+        .then(Ctx::in_promise()),
+    )
+    .on_command_async(
+        LOAD_DETAIL,
+        |d| WebApi::global().get_artist_overview(&d.id),
+        |_, data, d| data.artist_detail.overview.defer(d),
+        |_, data, r| data.artist_detail.overview.update(r),
+    )
 }
 
+/// Renders part of the promise loaded by `async_artist_info`; intentionally
+/// has no `LOAD_DETAIL` handler of its own.
 fn async_related_widget() -> impl Widget<AppState> {
     Async::new(utils::spinner_widget, related_widget, utils::error_widget)
-        .lens(AppState::artist_detail.then(ArtistDetail::related_artists))
-        .on_command_async(
-            LOAD_DETAIL,
-            |d| WebApi::global().get_related_artists(&d.id),
-            |_, data, d| data.artist_detail.related_artists.defer(d),
-            |_, data, r| data.artist_detail.related_artists.update(r),
-        )
+        .lens(AppState::artist_detail.then(ArtistDetail::overview))
 }
 
 pub fn artist_widget(horizontal: bool) -> impl Widget<Artist> {
@@ -205,12 +205,12 @@ fn albums_widget() -> impl Widget<WithCtx<ArtistAlbums>> {
         )
 }
 
-fn related_widget() -> impl Widget<Cached<Vector<Artist>>> {
+fn related_widget() -> impl Widget<Cached<ArtistOverview>> {
     Flex::column()
         .cross_axis_alignment(CrossAxisAlignment::Start)
         .with_child(header_widget("Related Artists"))
         .with_child(List::new(|| artist_widget(false)))
-        .lens(Cached::data)
+        .lens(Cached::data.then(ArtistOverview::related))
 }
 
 fn header_widget<T: Data>(text: impl Into<LabelText<T>>) -> impl Widget<T> {

--- a/psst-gui/src/webapi/client.rs
+++ b/psst-gui/src/webapi/client.rs
@@ -1088,83 +1088,7 @@ impl WebApi {
         Ok(releases)
     }
 
-    // https://developer.spotify.com/documentation/web-api/reference/get-an-artists-related-artists
-    pub fn get_related_artists(&self, id: &str) -> Result<Cached<Vector<Artist>>, Error> {
-        #[derive(Clone, Data, Deserialize)]
-        struct Artists {
-            artists: Vector<Artist>,
-        }
-        let request = &RequestBuilder::new(
-            format!("v1/artists/{id}/related-artists"),
-            Method::Get,
-            None,
-        );
-        let result: Cached<Artists> = self.load_cached(request, "related-artists", id)?;
-        Ok(result.map(|result| result.artists))
-    }
-
-    pub fn get_artist_info(&self, id: &str) -> Result<ArtistInfo, Error> {
-        #[derive(Clone, Data, Deserialize)]
-        pub struct Welcome {
-            data: Data1,
-        }
-
-        #[derive(Clone, Data, Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        pub struct Data1 {
-            artist_union: ArtistUnion,
-        }
-
-        #[derive(Clone, Data, Deserialize)]
-        pub struct ArtistUnion {
-            profile: Profile,
-            stats: Stats,
-            visuals: Visuals,
-        }
-
-        #[derive(Clone, Data, Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        pub struct Profile {
-            biography: Biography,
-            external_links: ExternalLinks,
-        }
-
-        #[derive(Clone, Data, Deserialize)]
-        pub struct Biography {
-            text: String,
-        }
-
-        #[derive(Clone, Data, Deserialize)]
-        pub struct ExternalLinks {
-            items: Vector<ExternalLinksItem>,
-        }
-
-        #[derive(Clone, Data, Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        pub struct Visuals {
-            avatar_image: AvatarImage,
-        }
-        #[derive(Clone, Data, Deserialize)]
-        pub struct AvatarImage {
-            sources: Vector<Image>,
-        }
-        #[derive(Clone, Data, Deserialize)]
-        pub struct ExternalLinksItem {
-            url: String,
-        }
-
-        #[derive(Clone, Data, Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        pub struct Stats {
-            followers: i64,
-            monthly_listeners: i64,
-            world_rank: i64,
-        }
-
-        let variables = json!( {
-            "locale": "",
-            "uri": format!("spotify:artist:{}", id),
-        });
+    fn artist_overview_request(&self, id: &str) -> RequestBuilder {
         let json = json!({
             "extensions": {
                 "persistedQuery": {
@@ -1173,20 +1097,184 @@ impl WebApi {
                 }
             },
             "operationName": "queryArtistOverview",
-            "variables": variables,
+            "variables": {
+                "locale": "",
+                "uri": format!("spotify:artist:{id}"),
+            },
         });
+        RequestBuilder::new("pathfinder/v2/query".to_string(), Method::Post, Some(json))
+            .set_base_uri("api-partner.spotify.com")
+            .header("User-Agent", Self::user_agent())
+            .partner_auth()
+    }
 
-        let request =
-            &RequestBuilder::new("pathfinder/v2/query".to_string(), Method::Post, Some(json))
-                .set_base_uri("api-partner.spotify.com")
-                .header("User-Agent", Self::user_agent());
+    // Related artists, sourced from `artistUnion.relatedContent` in the same
+    // `queryArtistOverview` response
+    pub fn get_related_artists(&self, id: &str) -> Result<Cached<Vector<Artist>>, Error> {
+        #[derive(Clone, Data, Deserialize)]
+        struct Welcome {
+            data: WelcomeData,
+        }
+        #[derive(Clone, Data, Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct WelcomeData {
+            artist_union: ArtistUnion,
+        }
+        #[derive(Clone, Data, Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct ArtistUnion {
+            #[serde(default)]
+            related_content: Option<RelatedContent>,
+        }
+        #[derive(Clone, Data, Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct RelatedContent {
+            #[serde(default)]
+            related_artists: RelatedArtists,
+        }
+        #[derive(Clone, Data, Default, Deserialize)]
+        struct RelatedArtists {
+            #[serde(default)]
+            items: Vector<RelatedArtist>,
+        }
+        #[derive(Clone, Data, Deserialize)]
+        struct RelatedArtist {
+            id: Arc<str>,
+            profile: RelatedProfile,
+            #[serde(default)]
+            visuals: Option<RelatedVisuals>,
+        }
+        #[derive(Clone, Data, Deserialize)]
+        struct RelatedProfile {
+            name: Arc<str>,
+        }
+        #[derive(Clone, Data, Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct RelatedVisuals {
+            #[serde(default)]
+            avatar_image: Option<RelatedAvatar>,
+        }
+        #[derive(Clone, Data, Deserialize)]
+        struct RelatedAvatar {
+            #[serde(default)]
+            sources: Vector<Image>,
+        }
+
+        let request = &self.artist_overview_request(id);
+        let result: Cached<Welcome> = self.load_cached(request, "related-artists", id)?;
+        Ok(result.map(|welcome| {
+            welcome
+                .data
+                .artist_union
+                .related_content
+                .map(|content| content.related_artists.items)
+                .unwrap_or_default()
+                .into_iter()
+                .map(|artist| Artist {
+                    id: artist.id,
+                    name: artist.profile.name,
+                    images: artist
+                        .visuals
+                        .and_then(|visuals| visuals.avatar_image)
+                        .map(|image| image.sources)
+                        .unwrap_or_default(),
+                })
+                .collect()
+        }))
+    }
+
+    // Artist bio, stats, image and external links from the pathfinder GraphQL
+    // `queryArtistOverview` operation (there is no REST equivalent).
+    pub fn get_artist_info(&self, id: &str) -> Result<ArtistInfo, Error> {
+        #[derive(Clone, Data, Deserialize)]
+        struct Welcome {
+            data: WelcomeData,
+        }
+        #[derive(Clone, Data, Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct WelcomeData {
+            artist_union: ArtistUnion,
+        }
+        // Sparse artists (no monthly listeners yet) omit `profile`, `stats` and
+        // `visuals` entirely, so every branch must tolerate their absence.
+        #[derive(Clone, Data, Deserialize)]
+        struct ArtistUnion {
+            #[serde(default)]
+            profile: Option<Profile>,
+            #[serde(default)]
+            stats: Option<Stats>,
+            #[serde(default)]
+            visuals: Option<Visuals>,
+        }
+        #[derive(Clone, Data, Default, Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Profile {
+            #[serde(default)]
+            biography: Option<Biography>,
+            #[serde(default)]
+            external_links: ExternalLinks,
+        }
+        #[derive(Clone, Data, Deserialize)]
+        struct Biography {
+            #[serde(default)]
+            text: Option<String>,
+        }
+        #[derive(Clone, Data, Default, Deserialize)]
+        struct ExternalLinks {
+            #[serde(default)]
+            items: Vector<ExternalLinksItem>,
+        }
+        #[derive(Clone, Data, Deserialize)]
+        struct ExternalLinksItem {
+            url: String,
+        }
+        #[derive(Clone, Data, Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Visuals {
+            #[serde(default)]
+            avatar_image: Option<AvatarImage>,
+        }
+        #[derive(Clone, Data, Deserialize)]
+        struct AvatarImage {
+            #[serde(default)]
+            sources: Vector<Image>,
+        }
+        // Individual counters can also be null even when `stats` is present.
+        #[derive(Clone, Data, Default, Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Stats {
+            #[serde(default)]
+            followers: Option<i64>,
+            #[serde(default)]
+            monthly_listeners: Option<i64>,
+            #[serde(default)]
+            world_rank: Option<i64>,
+        }
+
+        let request = &self.artist_overview_request(id);
         let result: Cached<Welcome> = self.load_cached(request, "artist-info", id)?;
+        let union = result.data.data.artist_union;
 
-        let hrefs: Vector<String> = result
-            .data
-            .data
-            .artist_union
-            .profile
+        let main_image = union
+            .visuals
+            .and_then(|visuals| visuals.avatar_image)
+            .and_then(|image| image.sources.into_iter().next())
+            .map(|source| source.url.clone())
+            .unwrap_or_else(|| Arc::from(""));
+
+        let profile = union.profile.unwrap_or_default();
+        let stats = union.stats.unwrap_or_default();
+
+        let bio = profile
+            .biography
+            .and_then(|biography| biography.text)
+            .map(|text| {
+                let sanitized = sanitize_str(&DEFAULT, &text).unwrap_or_default();
+                sanitized.replace("&amp;", "&")
+            })
+            .unwrap_or_default();
+
+        let artist_links = profile
             .external_links
             .items
             .into_iter()
@@ -1194,26 +1282,14 @@ impl WebApi {
             .collect();
 
         Ok(ArtistInfo {
-            main_image: Arc::from(
-                result.data.data.artist_union.visuals.avatar_image.sources[0]
-                    .url
-                    .to_string(),
-            ),
+            main_image,
             stats: ArtistStats {
-                followers: result.data.data.artist_union.stats.followers,
-                monthly_listeners: result.data.data.artist_union.stats.monthly_listeners,
-                world_rank: result.data.data.artist_union.stats.world_rank,
+                followers: stats.followers.unwrap_or(0),
+                monthly_listeners: stats.monthly_listeners.unwrap_or(0),
+                world_rank: stats.world_rank.unwrap_or(0),
             },
-            bio: {
-                let sanitized_bio = sanitize_str(
-                    &DEFAULT,
-                    &result.data.data.artist_union.profile.biography.text,
-                )
-                .unwrap_or_default();
-                sanitized_bio.replace("&amp;", "&")
-            },
-
-            artist_links: hrefs,
+            bio,
+            artist_links,
         })
     }
 }

--- a/psst-gui/src/webapi/client.rs
+++ b/psst-gui/src/webapi/client.rs
@@ -29,6 +29,7 @@ use psst_core::{
 use serde::{de::DeserializeOwned, Deserialize};
 use serde_json::json;
 use std::sync::OnceLock;
+use time::{Date, Month};
 use ureq::{
     http::{Response, StatusCode},
     Agent, Body,
@@ -37,9 +38,10 @@ use ureq::{
 use crate::{
     data::{
         self, utils::sanitize_html_string, Album, AlbumType, Artist, ArtistAlbums, ArtistInfo,
-        ArtistLink, ArtistStats, AudioAnalysis, Cached, Episode, EpisodeId, EpisodeLink, Image,
-        MixedView, Nav, Page, Playlist, PublicUser, Range, Recommendations, RecommendationsRequest,
-        SearchResults, SearchTopic, Show, SpotifyUrl, Track, TrackLines, UserProfile,
+        ArtistLink, ArtistStats, AudioAnalysis, Cached, DatePrecision, Episode, EpisodeId,
+        EpisodeLink, Image, MixedView, Nav, Page, Playlist, PublicUser, Range, Recommendations,
+        RecommendationsRequest, SearchResults, SearchTopic, Show, SpotifyUrl, Track, TrackLines,
+        UserProfile,
     },
     error::Error,
     ui::credits::TrackCredits,
@@ -803,6 +805,181 @@ impl WebApi {
     }
 }
 
+/// Persisted-query hashes for the pathfinder discography operations, extracted
+/// from the web player bundle.  Albums, singles and compilations all share one
+/// document (selected by `operationName`); appears-on is a separate one.
+const DISCOGRAPHY_HASH: &str = "5e07d323febb57b4a56a42abbf781490e58764aa45feb6e3dc0591564fc56599";
+const APPEARS_ON_HASH: &str = "9a4bb7a20d6720fe52d7b47bc001cfa91940ddf5e7113761460b4a288d18a4c1";
+
+// Shape of the `queryArtistDiscography*` / `queryArtistAppearsOn` responses.
+// Each operation populates a different field, so all are optional and the
+// caller selects the one it wants.
+#[derive(Deserialize)]
+struct DiscographyResponse {
+    data: DiscographyData,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DiscographyData {
+    artist_union: DiscographyUnion,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DiscographyUnion {
+    #[serde(default)]
+    discography: Discography,
+    #[serde(default)]
+    related_content: RelatedContent,
+}
+
+#[derive(Default, Deserialize)]
+struct Discography {
+    #[serde(default)]
+    albums: Option<DiscographySection>,
+    #[serde(default)]
+    singles: Option<DiscographySection>,
+    #[serde(default)]
+    compilations: Option<DiscographySection>,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RelatedContent {
+    #[serde(default)]
+    appears_on: Option<DiscographySection>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DiscographySection {
+    #[serde(default)]
+    total_count: i64,
+    #[serde(default)]
+    items: Vec<ReleaseHolder>,
+}
+
+#[derive(Deserialize)]
+struct ReleaseHolder {
+    releases: Releases,
+}
+
+#[derive(Deserialize)]
+struct Releases {
+    #[serde(default)]
+    items: Vec<Release>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Release {
+    id: Arc<str>,
+    name: Arc<str>,
+    #[serde(default)]
+    cover_art: CoverArt,
+    #[serde(default)]
+    date: Option<ReleaseDate>,
+    #[serde(rename = "type", default)]
+    release_type: Option<String>,
+    #[serde(default)]
+    artists: ReleaseArtists,
+}
+
+#[derive(Default, Deserialize)]
+struct CoverArt {
+    #[serde(default)]
+    sources: Vector<Image>,
+}
+
+#[derive(Deserialize)]
+struct ReleaseDate {
+    #[serde(default)]
+    year: Option<i32>,
+    #[serde(default)]
+    month: Option<u8>,
+    #[serde(default)]
+    day: Option<u8>,
+    #[serde(default)]
+    precision: Option<String>,
+}
+
+#[derive(Default, Deserialize)]
+struct ReleaseArtists {
+    #[serde(default)]
+    items: Vec<ReleaseArtist>,
+}
+
+#[derive(Deserialize)]
+struct ReleaseArtist {
+    uri: String,
+    profile: ReleaseArtistProfile,
+}
+
+#[derive(Deserialize)]
+struct ReleaseArtistProfile {
+    name: Arc<str>,
+}
+
+impl Release {
+    fn to_album(&self, default_type: AlbumType) -> Album {
+        let album_type = match self.release_type.as_deref() {
+            Some("ALBUM") => AlbumType::Album,
+            Some("SINGLE") => AlbumType::Single,
+            Some("COMPILATION") => AlbumType::Compilation,
+            _ => default_type,
+        };
+        let (release_date, release_date_precision) = self
+            .date
+            .as_ref()
+            .map(ReleaseDate::to_date)
+            .unwrap_or((None, None));
+
+        Album {
+            id: self.id.clone(),
+            name: self.name.clone(),
+            album_type,
+            images: self.cover_art.sources.clone(),
+            artists: self
+                .artists
+                .items
+                .iter()
+                .map(|artist| ArtistLink {
+                    id: artist.uri.rsplit(':').next().unwrap_or_default().into(),
+                    name: artist.profile.name.clone(),
+                })
+                .collect(),
+            copyrights: Vector::new(),
+            label: "".into(),
+            tracks: Vector::new(),
+            release_date,
+            release_date_precision,
+        }
+    }
+}
+
+impl ReleaseDate {
+    fn to_date(&self) -> (Option<Date>, Option<DatePrecision>) {
+        let precision = match self.precision.as_deref() {
+            Some("DAY") => Some(DatePrecision::Day),
+            Some("MONTH") => Some(DatePrecision::Month),
+            Some("YEAR") => Some(DatePrecision::Year),
+            _ => None,
+        };
+        // Only the year is required; month/day default to 1 so we can still form
+        // a valid `Date` even when precision is coarser than a full day.
+        let date = self.year.and_then(|year| {
+            let month = self
+                .month
+                .and_then(|month| Month::try_from(month).ok())
+                .unwrap_or(Month::January);
+            let day = self.day.filter(|day| *day >= 1).unwrap_or(1);
+            Date::from_calendar_date(year, month, day).ok()
+        });
+        (date, precision)
+    }
+}
+
 /// Artist endpoints.
 impl WebApi {
     // https://developer.spotify.com/documentation/web-api/reference/get-artist/
@@ -812,49 +989,103 @@ impl WebApi {
         Ok(result.data)
     }
 
-    // https://developer.spotify.com/documentation/web-api/reference/get-an-artists-albums/
+    // Albums, singles, compilations and appears-on each come from a separate
+    // pathfinder discography operation on `api-partner.spotify.com`, paginated
+    // independently.
     pub fn get_artist_albums(&self, id: &str) -> Result<ArtistAlbums, Error> {
-        let request = &RequestBuilder::new(format!("v1/artists/{id}/albums"), Method::Get, None)
-            .query("market", "from_token");
-        let result: Vector<Arc<Album>> = self.load_all_pages(request)?;
+        Ok(ArtistAlbums {
+            albums: self.artist_releases(
+                id,
+                "queryArtistDiscographyAlbums",
+                DISCOGRAPHY_HASH,
+                true,
+                AlbumType::Album,
+                |union| union.discography.albums.as_ref(),
+            )?,
+            singles: self.artist_releases(
+                id,
+                "queryArtistDiscographySingles",
+                DISCOGRAPHY_HASH,
+                true,
+                AlbumType::Single,
+                |union| union.discography.singles.as_ref(),
+            )?,
+            compilations: self.artist_releases(
+                id,
+                "queryArtistDiscographyCompilations",
+                DISCOGRAPHY_HASH,
+                true,
+                AlbumType::Compilation,
+                |union| union.discography.compilations.as_ref(),
+            )?,
+            appears_on: self.artist_releases(
+                id,
+                "queryArtistAppearsOn",
+                APPEARS_ON_HASH,
+                false,
+                AlbumType::Album,
+                |union| union.related_content.appears_on.as_ref(),
+            )?,
+        })
+    }
 
-        let mut artist_albums = ArtistAlbums {
-            albums: Vector::new(),
-            singles: Vector::new(),
-            compilations: Vector::new(),
-            appears_on: Vector::new(),
-        };
+    /// Fetch one discography section, paging until `totalCount` is exhausted.
+    /// `select` picks the section out of the response, `default_type` fills in
+    /// releases that omit their `type`, and `order` sends `DATE_DESC` (which the
+    /// appears-on operation rejects).
+    fn artist_releases(
+        &self,
+        id: &str,
+        operation: &str,
+        hash: &str,
+        order: bool,
+        default_type: AlbumType,
+        select: impl Fn(&DiscographyUnion) -> Option<&DiscographySection>,
+    ) -> Result<Vector<Arc<Album>>, Error> {
+        const PAGE: usize = 50;
 
-        let mut last_album_release_year = usize::MAX;
-        let mut last_single_release_year = usize::MAX;
+        let mut releases = Vector::new();
+        let mut offset = 0;
+        loop {
+            let mut variables = json!({
+                "uri": format!("spotify:artist:{id}"),
+                "offset": offset,
+                "limit": PAGE,
+            });
+            if order {
+                variables["order"] = json!("DATE_DESC");
+            }
+            let json = json!({
+                "operationName": operation,
+                "variables": variables,
+                "extensions": {
+                    "persistedQuery": { "version": 1, "sha256Hash": hash }
+                },
+            });
+            let request =
+                &RequestBuilder::new("pathfinder/v2/query".to_string(), Method::Post, Some(json))
+                    .set_base_uri("api-partner.spotify.com")
+                    .header("User-Agent", Self::user_agent())
+                    .partner_auth();
 
-        for album in result {
-            match album.album_type {
-                // Spotify is labeling albums and singles that should be labeled `appears_on` as `album` or `single`.
-                // They are still ordered properly though, with the most recent first, then 'appears_on'.
-                // So we just wait until they are no longer descending, then start putting them in the 'appears_on' Vec.
-                // NOTE: This will break if an artist has released 'appears_on' albums/singles before their first actual album/single.
-                AlbumType::Album => {
-                    if album.release_year_int() > last_album_release_year {
-                        artist_albums.appears_on.push_back(album)
-                    } else {
-                        last_album_release_year = album.release_year_int();
-                        artist_albums.albums.push_back(album)
-                    }
+            let response: DiscographyResponse = self.load(request)?;
+            let union = response.data.artist_union;
+            let Some(section) = select(&union) else {
+                break;
+            };
+
+            for holder in &section.items {
+                if let Some(release) = holder.releases.items.first() {
+                    releases.push_back(Arc::new(release.to_album(default_type.clone())));
                 }
-                AlbumType::Single => {
-                    if album.release_year_int() > last_single_release_year {
-                        artist_albums.appears_on.push_back(album);
-                    } else {
-                        last_single_release_year = album.release_year_int();
-                        artist_albums.singles.push_back(album);
-                    }
-                }
-                AlbumType::Compilation => artist_albums.compilations.push_back(album),
-                AlbumType::AppearsOn => artist_albums.appears_on.push_back(album),
+            }
+
+            offset += PAGE;
+            if section.items.is_empty() || offset >= section.total_count.max(0) as usize {
+                break;
             }
         }
-        Ok(artist_albums)
+        Ok(releases)
     }
 
     // https://developer.spotify.com/documentation/web-api/reference/get-an-artists-related-artists

--- a/psst-gui/src/webapi/client.rs
+++ b/psst-gui/src/webapi/client.rs
@@ -38,10 +38,10 @@ use ureq::{
 use crate::{
     data::{
         self, utils::sanitize_html_string, Album, AlbumType, Artist, ArtistAlbums, ArtistInfo,
-        ArtistLink, ArtistStats, AudioAnalysis, Cached, DatePrecision, Episode, EpisodeId,
-        EpisodeLink, Image, MixedView, Nav, Page, Playlist, PublicUser, Range, Recommendations,
-        RecommendationsRequest, SearchResults, SearchTopic, Show, SpotifyUrl, Track, TrackLines,
-        UserProfile,
+        ArtistLink, ArtistOverview, ArtistStats, AudioAnalysis, Cached, DatePrecision, Episode,
+        EpisodeId, EpisodeLink, Image, MixedView, Nav, Page, Playlist, PublicUser, Range,
+        Recommendations, RecommendationsRequest, SearchResults, SearchTopic, Show, SpotifyUrl,
+        Track, TrackLines, UserProfile,
     },
     error::Error,
     ui::credits::TrackCredits,
@@ -1088,7 +1088,91 @@ impl WebApi {
         Ok(releases)
     }
 
-    fn artist_overview_request(&self, id: &str) -> RequestBuilder {
+    // Artist bio, stats, image, external links and related artists, from the
+    // pathfinder GraphQL `queryArtistOverview` operation.  One response feeds
+    // the whole artist page, so it is fetched, cached and parsed as one.
+    pub fn get_artist_overview(&self, id: &str) -> Result<Cached<ArtistOverview>, Error> {
+        #[derive(Clone, Data, Deserialize)]
+        struct Welcome {
+            data: WelcomeData,
+        }
+        #[derive(Clone, Data, Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct WelcomeData {
+            artist_union: ArtistUnion,
+        }
+        // Sparse artists (no monthly listeners yet) omit `profile`, `stats`,
+        // `visuals` and `relatedContent` entirely, so every branch must
+        // tolerate their absence.
+        #[derive(Clone, Data, Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct ArtistUnion {
+            profile: Option<Profile>,
+            stats: Option<Stats>,
+            visuals: Option<Visuals>,
+            related_content: Option<RelatedContent>,
+        }
+        #[derive(Clone, Data, Default, Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Profile {
+            biography: Option<Biography>,
+            #[serde(default)]
+            external_links: ExternalLinks,
+        }
+        #[derive(Clone, Data, Deserialize)]
+        struct Biography {
+            text: Option<String>,
+        }
+        #[derive(Clone, Data, Default, Deserialize)]
+        struct ExternalLinks {
+            #[serde(default)]
+            items: Vector<ExternalLinksItem>,
+        }
+        #[derive(Clone, Data, Deserialize)]
+        struct ExternalLinksItem {
+            url: String,
+        }
+        // Individual counters can also be null even when `stats` is present.
+        #[derive(Clone, Data, Default, Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Stats {
+            followers: Option<i64>,
+            monthly_listeners: Option<i64>,
+            world_rank: Option<i64>,
+        }
+        #[derive(Clone, Data, Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Visuals {
+            avatar_image: Option<AvatarImage>,
+        }
+        #[derive(Clone, Data, Deserialize)]
+        struct AvatarImage {
+            #[serde(default)]
+            sources: Vector<Image>,
+        }
+        #[derive(Clone, Data, Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct RelatedContent {
+            #[serde(default)]
+            related_artists: RelatedArtists,
+        }
+        #[derive(Clone, Data, Default, Deserialize)]
+        struct RelatedArtists {
+            #[serde(default)]
+            items: Vector<RelatedArtist>,
+        }
+        // Related artists carry the same `visuals` shape as the artist itself.
+        #[derive(Clone, Data, Deserialize)]
+        struct RelatedArtist {
+            id: Arc<str>,
+            profile: RelatedProfile,
+            visuals: Option<Visuals>,
+        }
+        #[derive(Clone, Data, Deserialize)]
+        struct RelatedProfile {
+            name: Arc<str>,
+        }
+
         let json = json!({
             "extensions": {
                 "persistedQuery": {
@@ -1102,70 +1186,46 @@ impl WebApi {
                 "uri": format!("spotify:artist:{id}"),
             },
         });
-        RequestBuilder::new("pathfinder/v2/query".to_string(), Method::Post, Some(json))
-            .set_base_uri("api-partner.spotify.com")
-            .header("User-Agent", Self::user_agent())
-            .partner_auth()
-    }
-
-    // Related artists, sourced from `artistUnion.relatedContent` in the same
-    // `queryArtistOverview` response
-    pub fn get_related_artists(&self, id: &str) -> Result<Cached<Vector<Artist>>, Error> {
-        #[derive(Clone, Data, Deserialize)]
-        struct Welcome {
-            data: WelcomeData,
-        }
-        #[derive(Clone, Data, Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        struct WelcomeData {
-            artist_union: ArtistUnion,
-        }
-        #[derive(Clone, Data, Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        struct ArtistUnion {
-            #[serde(default)]
-            related_content: Option<RelatedContent>,
-        }
-        #[derive(Clone, Data, Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        struct RelatedContent {
-            #[serde(default)]
-            related_artists: RelatedArtists,
-        }
-        #[derive(Clone, Data, Default, Deserialize)]
-        struct RelatedArtists {
-            #[serde(default)]
-            items: Vector<RelatedArtist>,
-        }
-        #[derive(Clone, Data, Deserialize)]
-        struct RelatedArtist {
-            id: Arc<str>,
-            profile: RelatedProfile,
-            #[serde(default)]
-            visuals: Option<RelatedVisuals>,
-        }
-        #[derive(Clone, Data, Deserialize)]
-        struct RelatedProfile {
-            name: Arc<str>,
-        }
-        #[derive(Clone, Data, Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        struct RelatedVisuals {
-            #[serde(default)]
-            avatar_image: Option<RelatedAvatar>,
-        }
-        #[derive(Clone, Data, Deserialize)]
-        struct RelatedAvatar {
-            #[serde(default)]
-            sources: Vector<Image>,
-        }
-
-        let request = &self.artist_overview_request(id);
-        let result: Cached<Welcome> = self.load_cached(request, "related-artists", id)?;
+        let request =
+            &RequestBuilder::new("pathfinder/v2/query".to_string(), Method::Post, Some(json))
+                .set_base_uri("api-partner.spotify.com")
+                .header("User-Agent", Self::user_agent())
+                // `api-partner` rejects the Web API OAuth token with a 403; it
+                // needs the first-party Login5 bearer + client-token.
+                .partner_auth();
+        // The cache has no versioning, so the bucket name is effectively the
+        // schema version: changing the shape parsed here needs a new one.
+        let result: Cached<Welcome> = self.load_cached(request, "artist-overview", id)?;
         Ok(result.map(|welcome| {
-            welcome
-                .data
-                .artist_union
+            let union = welcome.data.artist_union;
+
+            let main_image = union
+                .visuals
+                .and_then(|visuals| visuals.avatar_image)
+                .and_then(|image| image.sources.into_iter().next())
+                .map(|source| source.url)
+                .unwrap_or_else(|| Arc::from(""));
+
+            let profile = union.profile.unwrap_or_default();
+            let stats = union.stats.unwrap_or_default();
+
+            let bio = profile
+                .biography
+                .and_then(|biography| biography.text)
+                .map(|text| {
+                    let sanitized = sanitize_str(&DEFAULT, &text).unwrap_or_default();
+                    sanitized.replace("&amp;", "&")
+                })
+                .unwrap_or_default();
+
+            let artist_links = profile
+                .external_links
+                .items
+                .into_iter()
+                .map(|link| link.url)
+                .collect();
+
+            let related = union
                 .related_content
                 .map(|content| content.related_artists.items)
                 .unwrap_or_default()
@@ -1179,118 +1239,22 @@ impl WebApi {
                         .map(|image| image.sources)
                         .unwrap_or_default(),
                 })
-                .collect()
+                .collect();
+
+            ArtistOverview {
+                info: ArtistInfo {
+                    main_image,
+                    stats: ArtistStats {
+                        followers: stats.followers.unwrap_or(0),
+                        monthly_listeners: stats.monthly_listeners.unwrap_or(0),
+                        world_rank: stats.world_rank.unwrap_or(0),
+                    },
+                    bio,
+                    artist_links,
+                },
+                related,
+            }
         }))
-    }
-
-    // Artist bio, stats, image and external links from the pathfinder GraphQL
-    // `queryArtistOverview` operation (there is no REST equivalent).
-    pub fn get_artist_info(&self, id: &str) -> Result<ArtistInfo, Error> {
-        #[derive(Clone, Data, Deserialize)]
-        struct Welcome {
-            data: WelcomeData,
-        }
-        #[derive(Clone, Data, Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        struct WelcomeData {
-            artist_union: ArtistUnion,
-        }
-        // Sparse artists (no monthly listeners yet) omit `profile`, `stats` and
-        // `visuals` entirely, so every branch must tolerate their absence.
-        #[derive(Clone, Data, Deserialize)]
-        struct ArtistUnion {
-            #[serde(default)]
-            profile: Option<Profile>,
-            #[serde(default)]
-            stats: Option<Stats>,
-            #[serde(default)]
-            visuals: Option<Visuals>,
-        }
-        #[derive(Clone, Data, Default, Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        struct Profile {
-            #[serde(default)]
-            biography: Option<Biography>,
-            #[serde(default)]
-            external_links: ExternalLinks,
-        }
-        #[derive(Clone, Data, Deserialize)]
-        struct Biography {
-            #[serde(default)]
-            text: Option<String>,
-        }
-        #[derive(Clone, Data, Default, Deserialize)]
-        struct ExternalLinks {
-            #[serde(default)]
-            items: Vector<ExternalLinksItem>,
-        }
-        #[derive(Clone, Data, Deserialize)]
-        struct ExternalLinksItem {
-            url: String,
-        }
-        #[derive(Clone, Data, Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        struct Visuals {
-            #[serde(default)]
-            avatar_image: Option<AvatarImage>,
-        }
-        #[derive(Clone, Data, Deserialize)]
-        struct AvatarImage {
-            #[serde(default)]
-            sources: Vector<Image>,
-        }
-        // Individual counters can also be null even when `stats` is present.
-        #[derive(Clone, Data, Default, Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        struct Stats {
-            #[serde(default)]
-            followers: Option<i64>,
-            #[serde(default)]
-            monthly_listeners: Option<i64>,
-            #[serde(default)]
-            world_rank: Option<i64>,
-        }
-
-        let request = &self.artist_overview_request(id);
-        let result: Cached<Welcome> = self.load_cached(request, "artist-info", id)?;
-        let union = result.data.data.artist_union;
-
-        let main_image = union
-            .visuals
-            .and_then(|visuals| visuals.avatar_image)
-            .and_then(|image| image.sources.into_iter().next())
-            .map(|source| source.url.clone())
-            .unwrap_or_else(|| Arc::from(""));
-
-        let profile = union.profile.unwrap_or_default();
-        let stats = union.stats.unwrap_or_default();
-
-        let bio = profile
-            .biography
-            .and_then(|biography| biography.text)
-            .map(|text| {
-                let sanitized = sanitize_str(&DEFAULT, &text).unwrap_or_default();
-                sanitized.replace("&amp;", "&")
-            })
-            .unwrap_or_default();
-
-        let artist_links = profile
-            .external_links
-            .items
-            .into_iter()
-            .map(|link| link.url)
-            .collect();
-
-        Ok(ArtistInfo {
-            main_image,
-            stats: ArtistStats {
-                followers: stats.followers.unwrap_or(0),
-                monthly_listeners: stats.monthly_listeners.unwrap_or(0),
-                world_rank: stats.world_rank.unwrap_or(0),
-            },
-            bio,
-            artist_links,
-        })
     }
 }
 


### PR DESCRIPTION
Related to #744, split out for review. Stacks on #746 (discography).

Finishes the artist page. Related artists and artist bio/stats/image/links now come from the `queryArtistOverview` pathfinder operation on `api-partner.spotify.com` (via `partner_auth`, added in #745).