### PR TITLE
fix(ui): make account setup and preferences windows reachable on small displays

### DIFF
--- a/psst-gui/src/ui/mod.rs
+++ b/psst-gui/src/ui/mod.rs
@@ -82,7 +82,7 @@ pub fn preferences_window() -> WindowDesc<AppState> {
     let win = WindowDesc::new(preferences_widget())
         .title("Preferences")
         .window_size(win_size)
-        .resizable(false)
+        .resizable(true)
         .show_title(false)
         .transparent_titlebar(true);
     if cfg!(target_os = "macos") {
@@ -96,7 +96,7 @@ pub fn account_setup_window() -> WindowDesc<AppState> {
     let win = WindowDesc::new(account_setup_widget())
         .title("Login")
         .window_size((theme::grid(50.0), theme::grid(45.0)))
-        .resizable(false)
+        .resizable(true)
         .show_title(false)
         .transparent_titlebar(true);
     if cfg!(target_os = "macos") {

--- a/psst-gui/src/ui/preferences.rs
+++ b/psst-gui/src/ui/preferences.rs
@@ -14,7 +14,7 @@ use druid::{
     text::ParseFormatter,
     widget::{
         Button, Controller, CrossAxisAlignment, Flex, Label, LineBreaking, MainAxisAlignment,
-        RadioGroup, SizedBox, Slider, TextBox, ViewSwitcher,
+        RadioGroup, SizedBox, Slider, TextBox, ViewSwitcher, Scroll,
     },
     Color, Data, Env, Event, EventCtx, Insets, Lens, LensExt, LifeCycle, LifeCycleCtx, Selector,
     Widget, WidgetExt,
@@ -51,6 +51,7 @@ where
 }
 
 pub fn account_setup_widget() -> impl Widget<AppState> {
+    Scroll::new(
     Flex::column()
         .must_fill_main_axis(true)
         .cross_axis_alignment(CrossAxisAlignment::Start)
@@ -71,8 +72,9 @@ pub fn account_setup_widget() -> impl Widget<AppState> {
         .with_spacer(theme::grid(6.0))
         .with_child(account_tab_widget(AccountTab::FirstSetup).expand_width())
         .padding(theme::grid(4.0))
-}
-
+    )
+    .vertical()
+}     
 pub fn preferences_widget() -> impl Widget<AppState> {
     const PROPAGATE_FLAGS: Selector = Selector::new("app.preferences.propagate-flags");
 
@@ -390,7 +392,7 @@ fn account_tab_widget(tab: AccountTab) -> impl Widget<AppState> {
                     .with_child(
                         TextBox::new()
                             .with_placeholder("Paste your Client ID here")
-                            .fix_width(theme::grid(40.0))
+                            .fix_width(theme::grid(24.0))
                             .lens(AppState::config.then(Config::webapi_client_id).map(
                                 |opt: &Option<String>| opt.clone().unwrap_or_default(),
                                 |opt: &mut Option<String>, val: String| {

--- a/psst-gui/src/ui/preferences.rs
+++ b/psst-gui/src/ui/preferences.rs
@@ -53,7 +53,6 @@ where
 pub fn account_setup_widget() -> impl Widget<AppState> {
     Scroll::new(
     Flex::column()
-        .must_fill_main_axis(true)
         .cross_axis_alignment(CrossAxisAlignment::Start)
         .with_spacer(theme::grid(2.0))
         .with_child(


### PR DESCRIPTION
I added scrolling and made it resizable, so displays above 100% will be able to login