### PR TITLE
fix(webapi): build show episodes from the show's own episode list

### DIFF
--- a/psst-gui/src/data/mod.rs
+++ b/psst-gui/src/data/mod.rs
@@ -55,7 +55,7 @@ pub use crate::data::{
         RecommendationsRequest, Toggled,
     },
     search::{Search, SearchResults, SearchTopic},
-    show::{Episode, EpisodeId, EpisodeLink, Show, ShowDetail, ShowEpisodes, ShowLink},
+    show::{Episode, Show, ShowDetail, ShowEpisode, ShowEpisodes, ShowLink},
     slider_scroll_scale::SliderScrollScale,
     track::{AudioAnalysis, Track, TrackId, TrackLines},
     user::{PublicUser, UserProfile},

--- a/psst-gui/src/data/show.rs
+++ b/psst-gui/src/data/show.rs
@@ -97,10 +97,41 @@ impl Episode {
     }
 }
 
-#[derive(Clone, Debug, Data, Lens, Deserialize)]
-pub struct EpisodeLink {
+/// An episode as it appears inside a show's episode list.  Identical to
+/// `Episode` except that it carries no `show` — the caller already knows which
+/// show it asked for, and `v1/episodes`, which would return the full shape, is
+/// 403 for third-party clients.
+#[derive(Clone, Debug, Deserialize)]
+pub struct ShowEpisode {
     pub id: EpisodeId,
     pub name: Arc<str>,
+    pub images: Vector<Image>,
+    pub description: Arc<str>,
+    pub languages: Vector<Arc<str>>,
+    #[serde(rename = "duration_ms")]
+    #[serde(deserialize_with = "super::utils::deserialize_millis")]
+    pub duration: Duration,
+    #[serde(deserialize_with = "super::utils::deserialize_date_option")]
+    pub release_date: Option<Date>,
+    pub release_date_precision: Option<DatePrecision>,
+    pub resume_point: Option<ResumePoint>,
+}
+
+impl ShowEpisode {
+    pub fn into_episode(self, show: ShowLink) -> Episode {
+        Episode {
+            id: self.id,
+            name: self.name,
+            show,
+            images: self.images,
+            description: self.description,
+            languages: self.languages,
+            duration: self.duration,
+            release_date: self.release_date,
+            release_date_precision: self.release_date_precision,
+            resume_point: self.resume_point,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Data, Lens, Deserialize)]

--- a/psst-gui/src/data/show.rs
+++ b/psst-gui/src/data/show.rs
@@ -57,7 +57,8 @@ impl ShowLink {
     }
 }
 
-#[derive(Clone, Debug, Data, Lens, Deserialize)]
+/// A resolved episode, built from the wire shape in [`ShowEpisode`].
+#[derive(Clone, Debug, Data, Lens)]
 pub struct Episode {
     pub id: EpisodeId,
     pub name: Arc<str>,
@@ -65,10 +66,7 @@ pub struct Episode {
     pub images: Vector<Image>,
     pub description: Arc<str>,
     pub languages: Vector<Arc<str>>,
-    #[serde(rename = "duration_ms")]
-    #[serde(deserialize_with = "super::utils::deserialize_millis")]
     pub duration: Duration,
-    #[serde(deserialize_with = "super::utils::deserialize_date_option")]
     #[data(same_fn = "PartialEq::eq")]
     pub release_date: Option<Date>,
     #[data(same_fn = "PartialEq::eq")]
@@ -99,14 +97,20 @@ impl Episode {
 
 /// An episode as it appears inside a show's episode list.  Identical to
 /// `Episode` except that it carries no `show` — the caller already knows which
-/// show it asked for, and `v1/episodes`, which would return the full shape, is
-/// 403 for third-party clients.
+/// show it asked for, and the endpoint that returns the full shape is 403 for
+/// third-party clients.
+///
+/// One unparseable field fails the whole page, so anything the UI can live
+/// without is defaulted.
 #[derive(Clone, Debug, Deserialize)]
 pub struct ShowEpisode {
     pub id: EpisodeId,
     pub name: Arc<str>,
+    #[serde(default)]
     pub images: Vector<Image>,
+    #[serde(default)]
     pub description: Arc<str>,
+    #[serde(default)]
     pub languages: Vector<Arc<str>>,
     #[serde(rename = "duration_ms")]
     #[serde(deserialize_with = "super::utils::deserialize_millis")]

--- a/psst-gui/src/ui/show.rs
+++ b/psst-gui/src/ui/show.rs
@@ -107,7 +107,7 @@ fn async_episodes_widget() -> impl Widget<AppState> {
     )
     .on_command_async(
         LOAD_DETAIL,
-        |d| WebApi::global().get_show_episodes(&d.id),
+        |d| WebApi::global().get_show_episodes(&d),
         |_, data, d| data.show_detail.episodes.defer(d),
         |_, data, (d, r)| {
             let r = r.map(|episodes| ShowEpisodes {

--- a/psst-gui/src/webapi/client.rs
+++ b/psst-gui/src/webapi/client.rs
@@ -39,9 +39,9 @@ use crate::{
     data::{
         self, utils::sanitize_html_string, Album, AlbumType, Artist, ArtistAlbums, ArtistInfo,
         ArtistLink, ArtistOverview, ArtistStats, AudioAnalysis, Cached, DatePrecision, Episode,
-        EpisodeId, EpisodeLink, Image, MixedView, Nav, Page, Playlist, PublicUser, Range,
-        Recommendations, RecommendationsRequest, SearchResults, SearchTopic, Show, SpotifyUrl,
-        Track, TrackLines, UserProfile,
+        Image, MixedView, Nav, Page, Playlist, PublicUser, Range, Recommendations,
+        RecommendationsRequest, SearchResults, SearchTopic, Show, ShowEpisode, ShowLink,
+        SpotifyUrl, Track, TrackLines, UserProfile,
     },
     error::Error,
     ui::credits::TrackCredits,
@@ -1281,38 +1281,23 @@ impl WebApi {
         Ok(result)
     }
 
-    // https://developer.spotify.com/documentation/web-api/reference/get-multiple-episodes
-    pub fn get_episodes(
-        &self,
-        ids: impl IntoIterator<Item = EpisodeId>,
-    ) -> Result<Vector<Arc<Episode>>, Error> {
-        #[derive(Deserialize)]
-        struct Episodes {
-            episodes: Vector<Arc<Episode>>,
-        }
-
-        let request = &RequestBuilder::new("v1/episodes", Method::Get, None)
-            .query("ids", ids.into_iter().map(|id| id.0.to_base62()).join(","))
-            .query("market", "from_token");
-        let result: Episodes = self.load(request)?;
-        Ok(result.episodes)
-    }
-
     // https://developer.spotify.com/documentation/web-api/reference/get-a-shows-episodes
-    pub fn get_show_episodes(&self, id: &str) -> Result<Vector<Arc<Episode>>, Error> {
-        let request = &RequestBuilder::new(format!("v1/shows/{id}/episodes"), Method::Get, None)
-            .query("market", "from_token");
+    pub fn get_show_episodes(&self, link: &ShowLink) -> Result<Vector<Arc<Episode>>, Error> {
+        let request = &RequestBuilder::new(
+            format!("v1/shows/{id}/episodes", id = link.id),
+            Method::Get,
+            None,
+        )
+        .query("market", "from_token");
 
         let mut results = Vector::new();
-        self.for_all_pages(request, |page: Page<Option<EpisodeLink>>| {
-            if !page.items.is_empty() {
-                let ids = page
-                    .items
+        self.for_all_pages(request, |page: Page<Option<ShowEpisode>>| {
+            results.extend(
+                page.items
                     .into_iter()
-                    .filter_map(|link| link.map(|link| link.id));
-                let episodes = self.get_episodes(ids)?;
-                results.append(episodes);
-            }
+                    .flatten()
+                    .map(|episode| Arc::new(episode.into_episode(link.clone()))),
+            );
             Ok(())
         })?;
 


### PR DESCRIPTION
Show/podcast pages are currently broken. psst resolves each page of the episode list through `v1/episodes`, which now returns 403. The list from `v1/shows/{id}/episodes` already carries the full episode objects, so we parses them now directly and drop the second request entirely.